### PR TITLE
[FIX] Newly created Org does not show up in org picker

### DIFF
--- a/src/components/CreateOrgs.vue
+++ b/src/components/CreateOrgs.vue
@@ -206,6 +206,7 @@ import { storeToRefs } from 'pinia';
 import _capitalize from 'lodash/capitalize';
 import _union from 'lodash/union';
 import _without from 'lodash/without';
+import { useQueryClient } from '@tanstack/vue-query';
 import { useVuelidate } from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import PvAutoComplete from 'primevue/autocomplete';
@@ -229,6 +230,7 @@ const isDemoData = ref(false);
 const toast = useToast();
 const authStore = useAuthStore();
 const { roarfirekit } = storeToRefs(authStore);
+const queryClient = useQueryClient();
 
 const state = reactive({
   orgName: '',
@@ -415,6 +417,7 @@ const submit = async () => {
       await roarfirekit.value
         .createOrg(orgType.value.firestoreCollection, orgData, isTestData.value, isDemoData.value)
         .then(() => {
+          queryClient.invalidateQueries({ queryKey: ['orgs'], exact: false });
           toast.add({ severity: 'success', summary: 'Success', detail: 'Org created', life: 3000 });
           submitted.value = false;
           resetForm();


### PR DESCRIPTION
See Notion link for bug details: 
https://www.notion.so/Newly-created-Org-does-not-show-up-in-org-picker-196244e26d9b8019ac3bf8afec6b2079

## Proposed changes

Invalidating the queryKey for orgs in OrgPicker when orgs successfully update in CreateOrgs.

Note: This is just a bare bones fix. I noticed a loading state could be added but wanted to keep it simple for my first commit. 

## Type of change

This is a bug fix. 


## Testing
Was able to repo the error locally
Manually tested locally by creating an org of type group and navigating to the Create Administration page. 