### PR TITLE
CAT Badge for Task Variants

### DIFF
--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -12,7 +12,7 @@
         />
       </div>
       <div>
-        <div class="flex flex-row">
+        <div class="flex align-items-center flex-row">
           <span class="font-bold text-lg pl-2" >{{ variant.task.name }}</span>
           <PvButton
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary ml-2"
@@ -22,6 +22,9 @@
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
+          <div v-if="variant?.variant?.params?.cat" class="flex ml-2">
+            <PvChip  class="bg-primary text-white h-2rem" label="CAT" />
+          </div>
         </div>
         <div class="pl-2 w-full">
           <p class="m-0"><span class="font-semibold">Variant name:</span> {{ variant.variant.name }}</p>
@@ -97,7 +100,8 @@
         <img class="w-4rem shadow-2 border-round" :src="variant.task.image || backupImage" :alt="variant.task.name" />
       </div>
       <div>
-        <div class="flex flex-row">
+        <!-- repeated code -->
+        <div class="flex align-items-center flex-row">
           <span class="font-bold" style="margin-left: 0.625rem">{{ variant.task.name }}</span>
           <PvButton
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary"
@@ -107,6 +111,9 @@
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
+          <div v-if="variant?.variant?.params?.cat" class="flex ml-2">
+            <PvChip  class="bg-primary text-white h-2rem" label="CAT" />
+          </div>
         </div>
         <div class="flex align-items-center gap-2">
           <p class="m-0 mt-1 ml-2">
@@ -256,6 +263,7 @@ import { ref } from 'vue';
 import _toPairs from 'lodash/toPairs';
 import PvButton from 'primevue/button';
 import PvColumn from 'primevue/column';
+import PvChip from 'primevue/chip';
 import PvDataTable from 'primevue/datatable';
 import PvDialog from 'primevue/dialog';
 import PvPopover from 'primevue/popover';


### PR DESCRIPTION
## Proposed changes

Added a CAT badge for task variants based on variant `CAT` field. I choose to add a badge instead of plain text to be more consistent with the rest of the application. 

I temporarily removed the FE filter for active tasks in order to surface CAT variants on the frontend which is what you see in the screenshots. However please note there are not any CAT tasks displayed based on the current data. I conferred with Zach to confirm this. So when testing you will not see these changes. 


Notion ticket: https://www.notion.so/Show-a-badge-for-task-variants-that-use-CAT-1a7244e26d9b80c4a67deea389504ab2

## Types of changes

What types of changes does this pull request introduce?

It looks like VariantCard could use some refactoring. There is some conditional logic up top that requires repeated code. I can work on this in a different PR. I highlighted the repetitive code with a comment. 

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [ ] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [ ] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [ ] Linting checks pass with my changes.
- [ ] Any existing unit tests pass with my changes.
- [ ] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [ ] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

This is the UI for the changes implemented: 
<img width="1129" alt="Screenshot 2025-03-04 at 2 15 13 PM" src="https://github.com/user-attachments/assets/24964998-7ce7-4d2d-ae45-ac625db484ef" />


Here are some alternative styles for the coloring of the badge. Lmk if either of these work better with the overall application / which stakeholders to consult. I noticed the Notion suggested orange. 

<img width="791" alt="Screenshot 2025-03-04 at 9 02 33 AM" src="https://github.com/user-attachments/assets/ebf4b1f8-8713-43af-8fbe-c4edd89cd490" />

^ default badge colors

<img width="561" alt="Screenshot 2025-03-04 at 1 49 37 PM" src="https://github.com/user-attachments/assets/4548643e-c5d0-4e62-a715-f3a0f99af6cd" />

^ only badge text color change
