### PR TITLE
Differentiated Feedback view based on User

### DIFF
--- a/src/components/UserActions.vue
+++ b/src/components/UserActions.vue
@@ -67,7 +67,6 @@
 
     const helpOptions = [
         { label: 'Researcher Documentation', value: 'researcherDocumentation' },
-        // BACKED OUT: Nav Bar Report an Issue
         { label: 'Report an Issue', value: 'reportAnIssue' }
     ];
 

--- a/src/components/UserActions.vue
+++ b/src/components/UserActions.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup>
-    import {ref} from 'vue';
+    import {ref, watchEffect} from 'vue';
     import useSignOutMutation from '@/composables/mutations/useSignOutMutation';
     import PvButton from 'primevue/button';
     import PvDropdown from 'primevue/dropdown';
@@ -54,34 +54,21 @@
     })
 
 
-    // BACKED OUT: getting access to feedback button
-    // onMounted(() => {
-    //     // Depreacted in latest version of Sentry and replaced with getFeedback()
-    //     const feedbackInstance = Sentry.getClient()?.getIntegration(Sentry.Feedback);
 
-    //     if (feedbackInstance && feedbackButton.value) {
-    //         feedbackInstance.attachTo(feedbackButton.value);
-    //     }
-    // });
-
-
-
-    // BACKED OUT: update styling of feedback modal based on view type to center
-    // watchEffect(() => {
-    //     const feedbackElement = document.getElementById('sentry-feedback');
-    //     if (feedbackElement) {
-    //         if (!props.isBasicView) {
-    //             feedbackElement.style.setProperty('--bottom', '28%');
-    //             feedbackElement.style.setProperty('--left', '40%');
-    //         }
-    //     }
-    // });
+    watchEffect(() => {
+        const feedbackElement = document.getElementById('sentry-feedback');
+        if (feedbackElement) {
+            if (!props.isBasicView) {
+                feedbackElement.style.setProperty('display', 'none');
+            }
+        }
+    });
 
 
     const helpOptions = [
         { label: 'Researcher Documentation', value: 'researcherDocumentation' },
         // BACKED OUT: Nav Bar Report an Issue
-        // { label: 'Report an Issue', value: 'reportAnIssue' }
+        { label: 'Report an Issue', value: 'reportAnIssue' }
     ];
 
     const profileOptions = [
@@ -93,8 +80,7 @@
         if (e.value === 'researcherDocumentation') {
             window.open('https://levante-researcher.super.site/', '_blank');
         } else if (e.value === 'reportAnIssue') {
-            // BACKED OUT: opens feedback modal
-            // feedbackButton.value.click();
+            window.open('https://watery-wrench-dee.notion.site/13c244e26d9b8005adbde4522455edfd', '_blank');
         }
     };
 


### PR DESCRIPTION
## Proposed changes

Participants (student (child), parent, and teacher) see the current feedback button ( floating button so they can access it during the tasks). Admins trigger the notion hosted feedback form when selecting “Report an Issue” from help menu in Nav Bar.

Notion ticket: https://www.notion.so/Feedback-Button-Modal-1b6244e26d9b80dfa4b4dc7d03f3fb67
Issue #106 

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
Screen recordings: 
Basic View = True (i.e. non-admins)
https://github.com/user-attachments/assets/154d852a-c636-4e43-813c-f562e234cdf4

Basic View = False (i.e. admins)
https://github.com/user-attachments/assets/785fc504-673a-449f-8474-6125f11d4d4b
