### PR TITLE
Create Assignment Page Updates

### DIFF
--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -41,7 +41,7 @@
             <span>{{ tasksDictionary[assessmentId]?.publicName ?? assessmentId }}</span>
             <span
               v-if="showParams"
-              v-tooltip.top="'Click to view params'"
+              v-tooltip.top="'View params'"
               class="pi pi-info-circle cursor-pointer ml-1"
               style="font-size: 1rem"
               @click="toggleParams($event, assessmentId)"

--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -41,7 +41,7 @@
             <span>{{ tasksDictionary[assessmentId]?.publicName ?? assessmentId }}</span>
             <span
               v-if="showParams"
-              v-tooltip.top="'View params'"
+              v-tooltip.top="'View parameters'"
               class="pi pi-info-circle cursor-pointer ml-1"
               style="font-size: 1rem"
               @click="toggleParams($event, assessmentId)"

--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -4,11 +4,11 @@
       <div class="flex flex-column mb-5">
         <div class="flex justify-content-between mb-2">
           <div class="flex align-items-center gap-3">
-            <i class="pi pi-sliders-h text-gray-400 rounded" style="font-size: 1.6rem" />
             <div class="admin-page-header">{{ header }}</div>
           </div>
         </div>
-        <div class="text-md text-gray-500 ml-6">{{ description }}</div>
+        <!-- do we need a margin here? -->
+        <div class="text-md text-gray-500">{{ description }}</div>
       </div>
 
       <PvDivider />
@@ -22,16 +22,17 @@
                 class="w-full"
                 data-cy="input-administration-name"
               />
-              <label for="administration-name" class="w-full">Administration Name</label>
+              <label for="administration-name" class="w-full">Your new assignment name</label>
               <small
                 v-if="v$.administrationName.$invalid && submitted"
                 class="p-error white-space-nowrap overflow-hidden text-overflow-ellipsis"
                 >Please name your administration</small
               >
             </PvFloatLabel>
+            <p class="mt-1 ml-1 text-sm text-gray-500">This name is visible to participants</p>
           </div>
 
-          <div class="field col-12 xl:col-6 mb-5">
+          <!-- <div class="field col-12 xl:col-6 mb-5">
             <PvFloatLabel>
               <PvInputText
                 id="administration-public-name"
@@ -46,7 +47,7 @@
                 >Please provide a public-facing name for this administration</small
               >
             </PvFloatLabel>
-          </div>
+          </div> -->
         </div>
         <div class="formgrid grid">
           <div class="field col-12 md:col-6 mb-5">
@@ -224,25 +225,25 @@ const props = defineProps({
 
 const header = computed(() => {
   if (props.adminId) {
-    return 'Edit an administration';
+    return 'Edit an assignment';
   }
 
-  return 'Create a new administration';
+  return 'Create new Assignment';
 });
 
 const description = computed(() => {
-  if (props.adminId) {
-    return 'Use this form to edit an existing administration.';
-  }
-  return 'Use this form to create a new administration and assign it to organizations.';
+  // if (props.adminId) {
+  //   return 'Use this form to edit an existing assignment.';
+  // }
+  return 'Assignments are bundles of tasks, surveys, and questionnaires that are sent to your users';
 });
 
 const submitLabel = computed(() => {
   if (props.adminId) {
-    return 'Update Administration';
+    return 'Update Assignment';
   }
 
-  return 'Create Administration';
+  return 'Create Assignment';
 });
 
 // +------------------------------------------------------------------------------------------------------------------+
@@ -579,6 +580,14 @@ watch([existingAdministrationData, allVariants], ([adminInfo, allVariantInfo]) =
 </script>
 
 <style lang="scss">
+.p-datepicker-today span {
+  background-color: var(--blue-100) !important; /* Change to your desired color */
+}
+
+.p-datepicker-today .p-datepicker-day-selected,.p-datepicker-day-selected span {
+  background-color: var(--primary-color) !important; /* Change to your selected date color */
+}
+
 .return-button {
   display: block;
   margin: 1rem 1.75rem;

--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -14,40 +14,24 @@
       <PvDivider />
       <div class="bg-gray-100 rounded p-5">
         <div class="formgrid grid mt-5">
-          <div class="field col-12 xl:col-6 mb-5">
-            <PvFloatLabel>
-              <PvInputText
+        <div class="field col-12 xl:col-6 mb-5">
+          <PvFloatLabel>
+            <PvInputText
                 id="administration-name"
                 v-model="state.administrationName"
                 class="w-full"
                 data-cy="input-administration-name"
-              />
-              <label for="administration-name" class="w-full">Your new assignment name</label>
-              <small
-                v-if="v$.administrationName.$invalid && submitted"
-                class="p-error white-space-nowrap overflow-hidden text-overflow-ellipsis"
-                >Please name your administration</small
-              >
+            />
+            <label for="administration-name" class="w-full">Your new assignment name</label>
+            <small
+              v-if="v$.administrationName.$invalid && submitted"
+              class="p-error white-space-nowrap overflow-hidden text-overflow-ellipsis"
+            >
+              Please name your administration
+            </small>
             </PvFloatLabel>
             <p class="mt-1 ml-1 text-sm text-gray-500">This name is visible to participants</p>
           </div>
-
-          <!-- <div class="field col-12 xl:col-6 mb-5">
-            <PvFloatLabel>
-              <PvInputText
-                id="administration-public-name"
-                v-model="state.administrationPublicName"
-                class="w-full"
-                data-cy="input-administration-name-public"
-              />
-              <label for="administration-public-name" class="w-full">Public Administration Name</label>
-              <small
-                v-if="v$.administrationPublicName.$invalid && submitted"
-                class="p-error white-space-nowrap overflow-hidden text-overflow-ellipsis"
-                >Please provide a public-facing name for this administration</small
-              >
-            </PvFloatLabel>
-          </div> -->
         </div>
         <div class="formgrid grid">
           <div class="field col-12 md:col-6 mb-5">
@@ -232,9 +216,6 @@ const header = computed(() => {
 });
 
 const description = computed(() => {
-  // if (props.adminId) {
-  //   return 'Use this form to edit an existing assignment.';
-  // }
   return 'Assignments are bundles of tasks, surveys, and questionnaires that are sent to your users';
 });
 

--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -22,7 +22,7 @@
                 class="w-full"
                 data-cy="input-administration-name"
             />
-            <label for="administration-name" class="w-full">Your new assignment name</label>
+            <label for="administration-name" class="w-full">Assignment Name</label>
             <small
               v-if="v$.administrationName.$invalid && submitted"
               class="p-error white-space-nowrap overflow-hidden text-overflow-ellipsis"
@@ -212,7 +212,7 @@ const header = computed(() => {
     return 'Edit an assignment';
   }
 
-  return 'Create new Assignment';
+  return 'Create New Assignment';
 });
 
 const description = computed(() => {

--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -7,7 +7,6 @@
             <div class="admin-page-header">{{ header }}</div>
           </div>
         </div>
-        <!-- do we need a margin here? -->
         <div class="text-md text-gray-500">{{ description }}</div>
       </div>
 

--- a/src/components/OrgPicker.vue
+++ b/src/components/OrgPicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grid">
     <div class="col-12 md:col-8">
-      <PvPanel class="m-0 p-0 h-full" :header="`Select ${forParentOrg ? 'your parent audience' : 'your audience'}`">
+      <PvPanel class="m-0 p-0 h-full" :header="`Select ${forParentOrg ? 'Parent Audience' : 'Audience'}`">
         <PvTabView v-if="claimsLoaded" v-model:active-index="activeIndex" class="m-0 p-0 org-tabs" lazy>
           <PvTabPanel v-for="orgType in orgHeaders" :key="orgType" :header="orgType.header">
             <div class="grid column-gap-3">

--- a/src/components/OrgPicker.vue
+++ b/src/components/OrgPicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grid">
     <div class="col-12 md:col-8">
-      <PvPanel class="m-0 p-0 h-full" :header="`Select ${forParentOrg ? 'parent audience' : 'audience'}`">
+      <PvPanel class="m-0 p-0 h-full" :header="`Select ${forParentOrg ? 'your parent audience' : 'your audience'}`">
         <PvTabView v-if="claimsLoaded" v-model:active-index="activeIndex" class="m-0 p-0 org-tabs" lazy>
           <PvTabPanel v-for="orgType in orgHeaders" :key="orgType" :header="orgType.header">
             <div class="grid column-gap-3">
@@ -64,7 +64,7 @@
       </PvPanel>
     </div>
     <div v-if="!forParentOrg" class="col-12 md:col-4">
-      <PvPanel class="h-full" header="Selected organizations">
+      <PvPanel class="h-full" header="Selected audience">
         <PvScrollPanel style="width: 100%; height: 26rem">
           <div v-for="orgKey in Object.keys(selectedOrgs)" :key="orgKey">
             <div v-if="selectedOrgs[orgKey].length > 0">

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -104,7 +104,7 @@
       </div>
       <div class="divider"></div>
       <div class="w-full lg:w-6" data-cy="panel-droppable-zone">
-        <div class="panel-title mb-2 text-base">Selected</div>
+        <div class="panel-title mb-2 text-base">Selected Tasks</div>
         <PvScrollPanel style="height: 32rem; width: 100%; overflow-y: auto">
           <!-- Draggable Zone 2 -->
           <VueDraggableNext

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -218,10 +218,8 @@ const taskOptions = computed(() => {
     let groupItems = [];
 
     tasks.forEach((task) => {
-      console.log(task);
       const taskKey = Object.keys(props.allVariants).find(
         (entry) => {
-          console.log(props.allVariants[entry][0].task.name === task, props.allVariants[entry][0].task.name, task)
           return props.allVariants[entry][0].task.name === task
         }
       );
@@ -259,9 +257,6 @@ const taskOptions = computed(() => {
       items: otherItems,
     });
   }
-
-  console.log(otherItems);
-
   return groupedOptions;
 });
 

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -104,7 +104,7 @@
       </div>
       <div class="divider"></div>
       <div class="w-full lg:w-6" data-cy="panel-droppable-zone">
-        <div class="panel-title mb-2 text-base">Selected Tasks</div>
+        <div class="panel-title mb-2 text-base">Selected tasks</div>
         <PvScrollPanel style="height: 32rem; width: 100%; overflow-y: auto">
           <!-- Draggable Zone 2 -->
           <VueDraggableNext

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -70,14 +70,6 @@
               </div>
             </template>
           </PvSelect>
-          <!-- <PvSelect
-            v-model="currentTask"
-            :options="taskOptions"
-            option-label="label"
-            option-value="value"
-            class="w-full mb-2"
-            placeholder="Select TaskID"
-          /> -->
           <PvScrollPanel style="height: 27.75rem; width: 100%; overflow-y: auto">
             <div v-if="!currentTask">Select a TaskID to display a list of variants.</div>
             <div v-else-if="!currentVariants.length">
@@ -212,8 +204,6 @@ const groupedTasks = {
 const taskOptions = computed(() => {
 
   let remainingTasks = new Set(Object.keys(props.allVariants));
-
-  // Transform groupedTasks into the desired nested format
   let groupedOptions = Object.entries(groupedTasks).map(([groupName, tasks]) => {
     let groupItems = [];
 
@@ -259,17 +249,6 @@ const taskOptions = computed(() => {
   }
   return groupedOptions;
 });
-
-// const taskOptions = computed(() => {
-//   return Object.entries(props.allVariants).map((entry) => {
-//     const key = entry[0];
-//     const value = entry[1];
-//     return {
-//       label: value[0].task.name ?? key,
-//       value: key,
-//     };
-//   });
-// });
 
 watch(
   () => props.inputVariants,

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -18,7 +18,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary ml-2"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'Click to view params'"
+              v-tooltip.top="'View params'"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
@@ -107,7 +107,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'Click to view params'"
+              v-tooltip.top="'View params'"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -18,7 +18,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary ml-2"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'View params'"
+              v-tooltip.top="'View parameters'"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
@@ -106,7 +106,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'View params'"
+              v-tooltip.top="'View parameters'"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -28,7 +28,6 @@
         </div>
         <div class="pl-2 w-full">
           <p class="m-0"><span class="font-semibold">Variant name:</span> {{ variant.variant.name }}</p>
-          <p class="m-0" v-if="isDev"><span  class="font-semibold">Variant id: </span>{{ variant.id }}</p>
         </div>
         <PvPopover ref="op" append-to="body" style="width: 40vh">
           <div class="flex justify-content-end mt-0 mb-2">
@@ -118,7 +117,11 @@
         <div class="flex align-items-center gap-2">
           <p class="m-0 mt-1 ml-2">
             <span class="font-bold">Variant name:</span> {{ variant.variant.name }} <br />
-            <span class="font-bold">Variant id: </span>{{ variant.id }}
+            <div
+              v-if="variant.variant?.conditions?.assigned?.conditions?.length > 0"
+            >
+              <span class="font-bold">Assigned to:</span> {{parseConditions(variant.variant?.conditions?.assigned).map(entry => entry.op === "EQUAL" ? `${entry.value}s` : `not ${entry.value}s`).join(", ")}}<br/>
+            </div>
           </p>
         </div>
       </div>
@@ -321,6 +324,7 @@ function iconClass() {
 }
 
 const parseConditions = (variant) => {
+  console.log(variant);
   return variant?.conditions;
 };
 

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -324,7 +324,6 @@ function iconClass() {
 }
 
 const parseConditions = (variant) => {
-  console.log(variant);
   return variant?.conditions;
 };
 


### PR DESCRIPTION
## Proposed changes

Notion
https://www.notion.so/5-Create-Assignment-Page-Updates-1a8244e26d9b8045ba7dd5f3c922d13b

- [x]  Title → "Create new Assignment"
- [x]  remove icon
- [x]  Update subtitle text 
    “Assignments are bundles of tasks, surveys, and questionnaires that are sent to your users”
- [x]  Change the highlighting of today’s date to be a different color. It looks like the current date is not available.
- [x]  Rename fields:
    - "Administration Name" → "Your new assignment name"
        - add text below the field: *“This name is visible to participants.”*
    - Remove "Public Administration Name" (copy from assignment name for backend for now)
    - "Select organizations here" → "Select your audience"
    - "Task Picker" → "Select tasks"
    - Group the tasks based on the grouping from [[this page on the researcher site](https://researcher.levante-network.org/measures/direct-child-measures)](https://researcher.levante-network.org/measures/direct-child-measures)
        - Adding titles for each section (ie. Language and Literacy, Executive Function, etc…)
    - Make sure all the shown tests in the list have the same names across the dashboard. Use the naming for each test from the research site (see link above). ( → this should be done in data, this should be a different task)
    - Tooltip text → "Click to view parameters"
    - Selected Variants → Selected
    - Change the tooltip hover text from “Click to view params” to → View parameters
- []  Rename “task” Instructions → Introduction (also use this for the grouping) (→ need to rename actual data, this should be a different task)
- [x]  Alphabetize tasks by grouping (Introduction is always first)
- [x]  Remove "Show only named variants” toggle. (This will be the default)
- [x]  Button: "Create Administration" → "Create Assignment"
- [x]  Selected Variants → Selected
    - After the task is added to the right column:
        - Hide the “Variant id” field.
        - Add text field “Assigned to"
            - Student (Every task)
            - All (Survey)

DID NOT IMPLEMENT: 
Rename “task” Instructions → Introduction (also use this for the grouping) (→ need to rename actual data, this should be a different task)
Make sure all the shown tests in the list have the same names across the dashboard. Use the naming for each test from the research site (see link above). ( → this should be done in data, this should be a different task. There was only one difference "&" verses "and")

Issue #104

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

##Screenshots

Task Groupings UI. There were no specific instructions on the UI for Groups. I added italics to make it a little more obvious but otherwise it's primevue's default behavior. I also added an "Other" section since there were tasks not accounted for in the researcher's site. 
<img width="485" alt="Screenshot 2025-03-25 at 11 36 06 AM" src="https://github.com/user-attachments/assets/a30a6341-790c-497d-bc25-7cba7b0914ef" />
Screen recording:
https://github.com/user-attachments/assets/83a4ff37-eeab-42d5-98e2-3e48a63e3001




Calendar UI. There was not a specific color chosen for today's data so I went with blue to not be confused with disabled entries in gray or the selected entry in our primary color (red)
<img width="469" alt="Screenshot 2025-03-25 at 11 34 20 AM" src="https://github.com/user-attachments/assets/07c720dd-29b3-4586-9ad3-c0fd4bce3e64" />


Assigned to. I realized we have a NOT EQUAL condition so I added UI for that as well. 
<img width="483" alt="Screenshot 2025-03-25 at 11 26 30 AM" src="https://github.com/user-attachments/assets/c928959e-4fbd-4b9f-88af-7d682b3f333a" />

