### PR TITLE
Feature: Enable admins to edit assignment

### DIFF
--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -8,7 +8,7 @@
         <div class="flex-grow-1 pr-3 mr-2 p-0 m-0">
           <h2 data-cy="h2-card-admin-title" class="sm:text-lg lg:text-lx m-0 h2-card-admin-title">{{ title }}</h2>
         </div>
-        <div v-if="isSuperAdmin" class="flex justify-content-end w-3 pl-5 pb-5 ml-2 mb-6">
+        <div class="flex justify-content-end w-3 pl-5 pb-5 ml-2 mb-6">
           <PvSpeedDial
             :model="speedDialItems"
             direction="left"


### PR DESCRIPTION
## Proposed changes

This PR implements [#110](https://github.com/levante-framework/levante-dashboard/issues/110)

<img width="1512" alt="Screenshot 2025-03-28 at 11 12 19" src="https://github.com/user-attachments/assets/0c5f298a-6634-4b74-a5cc-459f443077e6" />

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
Since only admins can see the assignments page, I believe the intention behind this activity is to make it visible to all users who access the page. Could you please help me validate this business rule?