### PR TITLE
Change district title to organization

### DIFF
--- a/src/components/ListUsers.vue
+++ b/src/components/ListUsers.vue
@@ -11,7 +11,7 @@
             <div class="bg-gray-100 px-5 py-2 rounded flex flex-column gap-3">
               <div class="flex flex-wrap align-items-center gap-2 justify-content-between">
                 <div class="uppercase font-light font-sm text-gray-400 mb-1">
-                  {{ singularizeFirestoreCollection(orgType) }}
+                  {{ i18n.t('listUsers.districtTitle') }}
                 </div>
                 <div class="text-xl text-gray-600">
                   <b> {{ orgName }} </b>
@@ -125,6 +125,7 @@
 <script setup>
 import { ref, reactive, onMounted, computed } from 'vue';
 import { storeToRefs } from 'pinia';
+import { useI18n } from 'vue-i18n';
 import { useVuelidate } from '@vuelidate/core';
 import { required, sameAs, minLength } from '@vuelidate/validators';
 import { useToast } from 'primevue/usetoast';
@@ -140,6 +141,7 @@ import RoarModal from './modals/RoarModal.vue';
 import RoarDataTable from '@/components/RoarDataTable.vue';
 
 const authStore = useAuthStore();
+const i18n = useI18n();
 
 const { roarfirekit } = storeToRefs(authStore);
 const initialized = ref(false);

--- a/src/translations/de/de-componentTranslations.json
+++ b/src/translations/de/de-componentTranslations.json
@@ -115,6 +115,9 @@
     "preparing": "Bereite Ihr Spiel vor!",
     "loading": "Laden"
   },
+   "listUsers": {
+    "districtTitle": "Organization"
+  },
   "sentryForm": {
     "formTitle": "Ein Problem bei LEVANTE melden",
     "buttonLabel": "Ein Problem melden",

--- a/src/translations/en/en-componentTranslations.json
+++ b/src/translations/en/en-componentTranslations.json
@@ -119,6 +119,9 @@
     "preparing": "Preparing your game!",
     "loading": "loading"
   },
+  "listUsers": {
+    "districtTitle": "Organization"
+  },
   "sentryForm": {
     "formTitle": "Report an Issue to LEVANTE",
     "buttonLabel": "Report an Issue",

--- a/src/translations/en/us/en-us-componentTranslations.json
+++ b/src/translations/en/us/en-us-componentTranslations.json
@@ -119,6 +119,9 @@
     "preparing": "Preparing your game!",
     "loading": "loading"
   },
+   "listUsers": {
+    "districtTitle": "Organization"
+  },
   "sentryForm": {
     "formTitle": "Report an Issue to LEVANTE",
     "buttonLabel": "Report an Issue",

--- a/src/translations/es/co/es-co-componentTranslations.json
+++ b/src/translations/es/co/es-co-componentTranslations.json
@@ -78,6 +78,9 @@
     "preparing": "¡Preparando tu juego!",
     "loading": "cargando"
   },
+  "listUsers": {
+    "districtTitle": "Organization"
+  },
   "sentryForm": {
     "formTitle": "Reportar un problema a LEVANTE",
     "buttonLabel": "Reportar un problema",

--- a/src/translations/es/es-componentTranslations.json
+++ b/src/translations/es/es-componentTranslations.json
@@ -120,6 +120,9 @@
     "preparing": "¡Preparando tu juego!",
     "loading": "cargando"
   },
+  "listUsers": {
+    "districtTitle": "Organization"
+  },
   "sentryForm": {
     "formTitle": "Reportar un problema a LEVANTE",
     "buttonLabel": "Reportar un problema",


### PR DESCRIPTION
## Proposed changes

I didn’t make any changes to the database — I just moved the responsibility of handling district titles to the frontend via the internationalization files.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the levante-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)


