### PR TITLE
Removed delete button for non-super admins

### DIFF
--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -196,8 +196,11 @@ const administrationStatus = computed(() => {
 });
 const administrationStatusBadge = computed(() => administrationStatus.value.toLowerCase()); 
 
-const speedDialItems = ref([
-  {
+const speedDialItems = computed( () => {
+  const items = [];
+
+  if (props.isSuperAdmin) {
+    items.push({
     label: 'Delete',
     icon: 'pi pi-trash',
     command: (event) => {
@@ -224,16 +227,20 @@ const speedDialItems = ref([
           });
         },
       });
-    },
-  },
-  {
+    },})
+  }
+
+  items.push({
     label: 'Edit',
     icon: 'pi pi-pencil',
     command: () => {
       router.push({ name: 'EditAdministration', params: { adminId: props.id } });
     },
-  },
-]);
+  })
+
+  return items;
+
+});
 
 const processedDates = computed(() => {
   return _mapValues(props.dates, (date) => {


### PR DESCRIPTION
## Proposed changes
https://github.com/levante-framework/levante-dashboard/issues/239

Remove The Delete Assignment button for admins. Super Admins should still be able to do it.


<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes
<!-- List any additional information that may be helpful to review or know about this change -->
