### PR TITLE
Task #394 Convert add group page into add group modal

### DIFF
--- a/src/assets/styles/components/_globals.scss
+++ b/src/assets/styles/components/_globals.scss
@@ -1,3 +1,3 @@
-#required-asterisk {
-  color: #ff0000;
+.required-asterisk {
+  color: var(--bright-red);
 }

--- a/src/assets/styles/components/_globals.scss
+++ b/src/assets/styles/components/_globals.scss
@@ -1,0 +1,3 @@
+#required-asterisk {
+  color: #ff0000;
+}

--- a/src/assets/styles/theme.scss
+++ b/src/assets/styles/theme.scss
@@ -6,6 +6,7 @@
 
 // Defaults
 @import 'components/defaults';
+@import 'components/globals';
 
 // Custom components
 @import 'components/navbar';

--- a/src/components/modals/AddGroupModal.vue
+++ b/src/components/modals/AddGroupModal.vue
@@ -25,7 +25,7 @@
             option-label="label"
             show-clear
           />
-          <label for="orgType">Group Type<span id="required-asterisk">*</span></label>
+          <label for="orgType">Group Type<span class="required-asterisk">*</span></label>
         </PvFloatLabel>
         <small v-if="v$.orgType.$error" class="p-error">Please select a type.</small>
       </div>
@@ -44,7 +44,7 @@
                 option-label="name"
                 show-clear
               />
-              <label for="parentDistrict">Site<span id="required-asterisk">*</span></label>
+              <label for="parentDistrict">Site<span class="required-asterisk">*</span></label>
             </PvFloatLabel>
             <small v-if="v$.parentDistrict.$error" class="p-error">Please select a site.</small>
           </div>
@@ -62,7 +62,7 @@
                   option-label="name"
                   show-clear
                 />
-                <label for="parentSchool">School<span id="required-asterisk">*</span></label>
+                <label for="parentSchool">School<span class="required-asterisk">*</span></label>
               </PvFloatLabel>
               <small v-if="v$.parentSchool.$error" class="p-error">Please select a school.</small>
             </div>
@@ -73,7 +73,7 @@
       <div class="flex flex-column gap-1 w-full">
         <PvFloatLabel>
           <PvInputText id="orgName" v-model="orgName" class="w-full" data-cy="input-org-name" />
-          <label for="orgName">{{ orgTypeLabel }} Name<span id="required-asterisk">*</span></label>
+          <label for="orgName">{{ orgTypeLabel }} Name<span class="required-asterisk">*</span></label>
         </PvFloatLabel>
         <small v-if="v$.orgName.$error" class="p-error">Please supply a name.</small>
       </div>

--- a/src/components/modals/AddGroupModal.vue
+++ b/src/components/modals/AddGroupModal.vue
@@ -1,0 +1,300 @@
+<template>
+  <PvDialog
+    :draggable="false"
+    :visible="props.isVisible"
+    style="width: 100%; max-width: 600px"
+    modal
+    @update:visible="handleOnClose"
+  >
+    <template #header>
+      <div class="flex flex-column gap-1">
+        <h2 class="m-0 font-bold">Add New {{ orgTypeLabel }}</h2>
+        <p class="m-0 text-gray-500">Use the form below to create a new group.</p>
+      </div>
+    </template>
+
+    <div class="flex flex-column gap-5 m-0 mt-4">
+      <div class="flex flex-column gap-1 w-full">
+        <PvFloatLabel>
+          <PvSelect
+            v-model="orgType"
+            :options="orgTypes"
+            class="w-full"
+            data-cy="dropdown-org-type"
+            input-id="orgType"
+            option-label="label"
+            show-clear
+          />
+          <label for="orgType">Group Type<span id="required-asterisk">*</span></label>
+        </PvFloatLabel>
+        <small v-if="v$.orgType.$error" class="p-error">Please select a type.</small>
+      </div>
+
+      <div v-if="parentOrgRequired" class="">
+        <div class="flex w-full gap-3">
+          <div class="flex flex-column gap-1 w-full">
+            <PvFloatLabel class="w-full">
+              <PvSelect
+                v-model="parentDistrict"
+                :loading="isLoadingDistricts"
+                :options="districts"
+                class="w-full"
+                data-cy="dropdown-parent-district"
+                input-id="parentDistrict"
+                option-label="name"
+                show-clear
+              />
+              <label for="parentDistrict">Site<span id="required-asterisk">*</span></label>
+            </PvFloatLabel>
+            <small v-if="v$.parentDistrict.$error" class="p-error">Please select a site.</small>
+          </div>
+
+          <div v-if="orgType.singular === 'class'" class="w-full">
+            <div class="flex flex-column gap-1 w-full">
+              <PvFloatLabel class="w-full">
+                <PvSelect
+                  v-model="parentSchool"
+                  :loading="!schoolDropdownEnabled"
+                  :options="schools"
+                  class="w-full"
+                  data-cy="dropdown-parent-school"
+                  input-id="parentSchool"
+                  option-label="name"
+                  show-clear
+                />
+                <label for="parentSchool">School<span id="required-asterisk">*</span></label>
+              </PvFloatLabel>
+              <small v-if="v$.parentSchool.$error" class="p-error">Please select a school.</small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-column gap-1 w-full">
+        <PvFloatLabel>
+          <PvInputText id="orgName" v-model="orgName" class="w-full" data-cy="input-org-name" />
+          <label for="orgName">{{ orgTypeLabel }} Name<span id="required-asterisk">*</span></label>
+        </PvFloatLabel>
+        <small v-if="v$.orgName.$error" class="p-error">Please supply a name.</small>
+      </div>
+
+      <p class="m-0">Optional fields:</p>
+
+      <PvFloatLabel>
+        <PvAutoComplete
+          v-model="tags"
+          class="w-full"
+          data-cy="input-autocomplete"
+          dropdown
+          multiple
+          name="tags"
+          :options="allTags"
+          :suggestions="tagSuggestions"
+          @complete="searchTags"
+        />
+        <label for="tags">Tags</label>
+      </PvFloatLabel>
+    </div>
+
+    <template #footer>
+      <div class="modal-footer">
+        <PvButton
+          class="border-none border-round bg-white text-primary p-2 hover:surface-200"
+          label="Cancel"
+          @click="handleOnClose"
+        ></PvButton>
+        <PvButton :label="`Add ${orgTypeLabel}`" @click="submit">
+          <i v-if="isSubmittingOrg" class="pi pi-spinner pi-spin"></i>
+        </PvButton>
+      </div>
+    </template>
+  </PvDialog>
+</template>
+
+<script setup lang="ts">
+import _capitalize from 'lodash/capitalize';
+import _union from 'lodash/union';
+import _without from 'lodash/without';
+import { computed, ref, toRaw } from 'vue';
+import { required, requiredIf } from '@vuelidate/validators';
+import { TOAST_DEFAULT_LIFE_DURATION } from '@/constants/toasts';
+import { useToast } from 'primevue/usetoast';
+import PvAutoComplete from 'primevue/autocomplete';
+import PvButton from 'primevue/button';
+import PvDialog from 'primevue/dialog';
+import PvFloatLabel from 'primevue/floatlabel';
+import PvInputText from 'primevue/inputtext';
+import PvSelect from 'primevue/select';
+import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
+import useDistrictsListQuery from '@/composables/queries/useDistrictsListQuery';
+import useGroupsListQuery from '@/composables/queries/useGroupsListQuery';
+import useSchoolClassesQuery from '@/composables/queries/useSchoolClassesQuery';
+import useUpsertOrgMutation from '@/composables/mutations/useUpsertOrgMutation';
+import useVuelidate from '@vuelidate/core';
+
+interface OrgType {
+  firestoreCollection: string;
+  label: string;
+  singular: string;
+}
+
+interface Props {
+  isVisible: boolean;
+}
+
+interface Emits {
+  (event: 'close'): void;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<Emits>();
+
+const toast = useToast();
+
+const initialized = ref(true);
+const orgName = ref('');
+const orgType = ref<OrgType | null>(null);
+const orgTypes: OrgType[] = [
+  { firestoreCollection: 'districts', singular: 'district', label: 'Site' },
+  { firestoreCollection: 'schools', singular: 'school', label: 'School' },
+  { firestoreCollection: 'classes', singular: 'class', label: 'Class' },
+  { firestoreCollection: 'groups', singular: 'group', label: 'Cohort' },
+];
+const parentDistrict = ref(undefined);
+const parentSchool = ref(undefined);
+const tags = ref([]);
+const tagSuggestions = ref([]);
+
+const v$ = useVuelidate(
+  {
+    orgType: {
+      required,
+    },
+    orgName: {
+      required,
+    },
+    parentDistrict: {
+      required: requiredIf(() => ['school', 'class', 'group'].includes(orgType?.value?.singular || '')),
+    },
+    parentSchool: {
+      required: requiredIf(() => orgType?.value?.singular === 'class'),
+    },
+  },
+  {
+    orgType,
+    orgName,
+    parentDistrict,
+    parentSchool,
+  },
+);
+
+const allTags = computed(() => {
+  const districtTags = (districts.value ?? []).map((org) => org.tags);
+  const schoolTags = (districts.value ?? []).map((org) => org.tags);
+  const classTags = (classes.value ?? []).map((org) => org.tags);
+  const groupTags = (groups.value ?? []).map((org) => org.tags);
+  return _without(_union(...districtTags, ...schoolTags, ...classTags, ...groupTags), undefined) || [];
+});
+const classQueryEnabled = computed(() => initialized.value && parentSchool?.value !== undefined);
+const orgTypeLabel = computed(() => (orgType.value ? _capitalize(orgType.value.label) : 'Group'));
+const parentOrgRequired = computed(() => ['school', 'class', 'group'].includes(orgType.value?.singular || ''));
+const selectedDistrict = computed(() => parentDistrict?.value?.id);
+const selectedSchool = computed(() => parentSchool?.value?.id);
+const schoolQueryEnabled = computed(() => {
+  return initialized.value && parentDistrict?.value !== undefined;
+});
+const schoolDropdownEnabled = computed(() => {
+  return parentDistrict.value && !isFetchingSchools.value;
+});
+
+const { mutate: upsertOrg, isPending: isSubmittingOrg } = useUpsertOrgMutation();
+
+const { data: classes } = useSchoolClassesQuery(selectedSchool, {
+  enabled: classQueryEnabled,
+});
+
+const { data: districts, loading: isLoadingDistricts } = useDistrictsListQuery({
+  enabled: initialized,
+});
+
+const { data: groups } = useGroupsListQuery({
+  enabled: initialized,
+});
+
+const { isFetching: isFetchingSchools, data: schools } = useDistrictSchoolsQuery(selectedDistrict, {
+  enabled: schoolQueryEnabled,
+});
+
+const handleOnClose = () => {
+  resetForm();
+  emit('close');
+};
+
+const resetForm = () => {
+  orgName.value = '';
+  orgType.value = null;
+  tags.value = [];
+  parentDistrict.value = undefined;
+  parentSchool.value = undefined;
+  v$.value.$reset();
+};
+
+const searchTags = (e) => {
+  const query = e.query.toLowerCase();
+  let filteredOptions = allTags.value.filter((opt) => opt.toLowerCase().includes(query));
+
+  if (filteredOptions.length === 0 && query) {
+    filteredOptions.push(query);
+  } else {
+    filteredOptions = filteredOptions.map((opt) => opt);
+  }
+
+  tagSuggestions.value = filteredOptions;
+};
+
+const submit = async () => {
+  const isFormValid = await v$.value.$validate();
+
+  if (!isFormValid) {
+    return toast.add({
+      severity: 'warn',
+      summary: 'Validation Error',
+      detail: 'Please check the form for errors.',
+      life: TOAST_DEFAULT_LIFE_DURATION,
+    });
+  }
+
+  const data = {
+    name: orgName.value,
+    type: orgType.value?.firestoreCollection,
+    tags: tags.value?.length > 0 ? tags.value : [],
+    schoolId: toRaw(parentSchool.value)?.id,
+    districtId: toRaw(parentDistrict.value)?.id,
+    parentOrgId: toRaw(parentDistrict.value)?.id,
+  };
+
+  upsertOrg(data, {
+    onSuccess: () => {
+      toast.add({
+        severity: 'success',
+        summary: 'Success',
+        detail: `${orgTypeLabel.value} created successfully`,
+        life: TOAST_DEFAULT_LIFE_DURATION,
+      });
+
+      handleOnClose();
+    },
+    onError: (error) => {
+      toast.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: error.message,
+        life: TOAST_DEFAULT_LIFE_DURATION,
+      });
+
+      console.error(`Error creating ${orgTypeLabel.value}:`, error);
+    },
+  });
+};
+</script>

--- a/src/components/modals/AddGroupModal.vue
+++ b/src/components/modals/AddGroupModal.vue
@@ -8,8 +8,8 @@
   >
     <template #header>
       <div class="flex flex-column gap-1">
-        <h2 class="m-0 font-bold">Add New {{ orgTypeLabel }}</h2>
-        <p class="m-0 text-gray-500">Use the form below to create a new group.</p>
+        <h2 class="m-0 font-bold" data-testid="modalTitle">Add New {{ orgTypeLabel }}</h2>
+        <p class="m-0 text-gray-500" data-testid="modalDescription">Use the form below to create a new group.</p>
       </div>
     </template>
 
@@ -103,7 +103,7 @@
           label="Cancel"
           @click="handleOnClose"
         ></PvButton>
-        <PvButton :label="`Add ${orgTypeLabel}`" @click="submit">
+        <PvButton :label="`Add ${orgTypeLabel}`" data-testid="submitBtn" @click="submit">
           <i v-if="isSubmittingOrg" class="pi pi-spinner pi-spin"></i>
         </PvButton>
       </div>
@@ -152,7 +152,6 @@ const emit = defineEmits<Emits>();
 
 const toast = useToast();
 
-const initialized = ref(true);
 const orgName = ref('');
 const orgType = ref<OrgType | null>(null);
 const orgTypes: OrgType[] = [
@@ -196,14 +195,12 @@ const allTags = computed(() => {
   const groupTags = (groups.value ?? []).map((org) => org.tags);
   return _without(_union(...districtTags, ...schoolTags, ...classTags, ...groupTags), undefined) || [];
 });
-const classQueryEnabled = computed(() => initialized.value && parentSchool?.value !== undefined);
+const classQueryEnabled = computed(() => parentSchool?.value !== undefined);
 const orgTypeLabel = computed(() => (orgType.value ? _capitalize(orgType.value.label) : 'Group'));
 const parentOrgRequired = computed(() => ['school', 'class', 'group'].includes(orgType.value?.singular || ''));
 const selectedDistrict = computed(() => parentDistrict?.value?.id);
 const selectedSchool = computed(() => parentSchool?.value?.id);
-const schoolQueryEnabled = computed(() => {
-  return initialized.value && parentDistrict?.value !== undefined;
-});
+const schoolQueryEnabled = computed(() => parentDistrict?.value !== undefined);
 const schoolDropdownEnabled = computed(() => {
   return parentDistrict.value && !isFetchingSchools.value;
 });
@@ -214,13 +211,9 @@ const { data: classes } = useSchoolClassesQuery(selectedSchool, {
   enabled: classQueryEnabled,
 });
 
-const { data: districts, loading: isLoadingDistricts } = useDistrictsListQuery({
-  enabled: initialized,
-});
+const { data: districts, loading: isLoadingDistricts } = useDistrictsListQuery();
 
-const { data: groups } = useGroupsListQuery({
-  enabled: initialized,
-});
+const { data: groups } = useGroupsListQuery();
 
 const { isFetching: isFetchingSchools, data: schools } = useDistrictSchoolsQuery(selectedDistrict, {
   enabled: schoolQueryEnabled,

--- a/src/components/tests/AddGroupModal.test.js
+++ b/src/components/tests/AddGroupModal.test.js
@@ -1,0 +1,148 @@
+import AddGroupModal from '@/components/modals/AddGroupModal.vue';
+import * as VueQuery from '@tanstack/vue-query';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import PvAutoComplete from 'primevue/autocomplete';
+import PvButton from 'primevue/button';
+import PrimeVue from 'primevue/config';
+import PvDialog from 'primevue/dialog';
+import PvFloatLabel from 'primevue/floatlabel';
+import PvInputText from 'primevue/inputtext';
+import PvSelect from 'primevue/select';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+const mockUseUpsertOrgMutation = vi.fn();
+
+vi.mock('@/composables/mutations/useUpsertOrgMutation', () => ({
+  default: () => ({
+    mutate: mockUseUpsertOrgMutation,
+    isPending: false,
+    error: null,
+  }),
+}));
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: () => vi.fn(),
+  }),
+}));
+
+const mountOptions = {
+  attachTo: document.body,
+  global: {
+    components: {
+      PvDialog,
+      PvFloatLabel,
+      PvSelect,
+      PvInputText,
+      PvButton,
+      PvAutoComplete,
+    },
+    plugins: [PrimeVue, VueQuery.VueQueryPlugin],
+  },
+  props: {
+    isVisible: true,
+  },
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('AddGroupModal.vue', () => {
+  it('should render the component (when visible)', async () => {
+    const wrapper = mount(AddGroupModal, mountOptions);
+    await nextTick();
+
+    expect(wrapper.exists()).toBe(true);
+
+    const modalTitle = document.querySelector('[data-testid="modalTitle"]');
+    expect(modalTitle).not.toBeNull();
+    expect(modalTitle.textContent).toContain('Add New Group');
+
+    wrapper.unmount();
+  });
+
+  it('should NOT render the component (when NOT visible)', async () => {
+    const wrapper = mount(AddGroupModal, {
+      ...mountOptions,
+      props: {
+        isVisible: false,
+      },
+    });
+    await nextTick();
+
+    expect(wrapper.exists()).toBe(true);
+
+    const modalTitle = document.querySelector('[data-testid="modalTitle"]');
+    expect(modalTitle).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it('should show an error if a required field is not filled in', async () => {
+    const wrapper = mount(AddGroupModal, mountOptions);
+    await nextTick();
+
+    const submitBtn = document.querySelector('[data-testid="submitBtn"]');
+    expect(submitBtn).not.toBeNull();
+    expect(submitBtn.textContent).toContain('Add Group');
+
+    await submitBtn.click();
+
+    const errorMessages = document.querySelectorAll('.p-error');
+    // By default, we only have 2 required fields
+    expect(errorMessages.length).toBe(2);
+
+    wrapper.unmount();
+  });
+
+  it('should submit the form if everything is ok', async () => {
+    const wrapper = mount(AddGroupModal, mountOptions);
+    await nextTick();
+
+    // First, we select the orgType dropdown
+    const orgTypeDropdown = document.querySelector('[data-cy="dropdown-org-type"]');
+    expect(orgTypeDropdown).not.toBeNull();
+    // Then we click it
+    await orgTypeDropdown.click();
+    await nextTick();
+
+    // Now, select the options to make sure the click action worked
+    const orgTypeDropdownOptions = document.querySelectorAll('.p-select-option');
+    // We must have 4 options: Site, School, Class and Cohort
+    expect(orgTypeDropdownOptions.length).toBe(4);
+
+    // Select the Site option and click on it
+    const siteOption = orgTypeDropdownOptions.find((option) => option.textContent === 'Site');
+    expect(siteOption).not.toBeNull();
+    await siteOption.click();
+    await nextTick();
+
+    // Now we provide a site name
+    const orgName = document.querySelector('[data-cy="input-org-name"]');
+    expect(orgName).not.toBeNull();
+    orgName.value = 'Test Site';
+    orgName.dispatchEvent(new Event('input'));
+    await nextTick();
+
+    // Mocking the vuelidate
+    wrapper.vm.v$.$validate = () => Promise.resolve(true);
+
+    // After that, we select the submit button and check if it says "Add Site"
+    const submitBtn = document.querySelector('[data-testid="submitBtn"]');
+    expect(submitBtn).not.toBeNull();
+    expect(submitBtn.textContent).toContain('Add Site');
+
+    await submitBtn.click();
+
+    const errorMessages = document.querySelectorAll('.p-error');
+    // We should NOT have any errors
+    expect(errorMessages.length).toBe(0);
+
+    expect(mockUseUpsertOrgMutation).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+  });
+});

--- a/src/pages/groups/ListGroups.vue
+++ b/src/pages/groups/ListGroups.vue
@@ -1,13 +1,12 @@
 <template>
-  <PvToast />
   <main class="container main w-full">
     <section class="main-body">
       <div class="flex flex-column mb-5">
         <div class="flex flex-column align-items-start mb-2 md:flex-row w-full justify-content-between">
           <div class="flex align-items-center gap-3 mb-4 md:mb-0">
             <div class="admin-page-header mr-4">Groups</div>
-            <PvButton class="bg-primary text-white border-none p-2 ml-auto" data-testid="add-group-btn" @click="newGroup"> Add Group </PvButton>
-            <PvButton class="bg-primary text-white border-none p-2 ml-auto" data-testid="add-users-btn" @click="addUsers"> Add Users </PvButton>
+            <PvButton class="bg-primary text-white border-none p-2 ml-auto" data-testid="add-group-btn" @click="isAddGroupModalVisible = true">Add Group</PvButton>
+            <PvButton class="bg-primary text-white border-none p-2 ml-auto" data-testid="add-users-btn" @click="addUsers">Add Users</PvButton>
           </div>
           <div class="flex align-items-center justify-content-end w-full md:w-auto">
             <span class="p-input-icon-left p-input-icon-right">
@@ -151,6 +150,8 @@
       </div>
     </template>
   </RoarModal>
+
+  <AddGroupModal :isVisible="isAddGroupModalVisible" @close="isAddGroupModalVisible = false" />
 </template>
 <script setup>
 import { ref, computed, onMounted, watch, watchEffect } from 'vue';
@@ -165,7 +166,6 @@ import PvInputGroup from 'primevue/inputgroup';
 import PvInputText from 'primevue/inputtext';
 import PvTabPanel from 'primevue/tabpanel';
 import PvTabView from 'primevue/tabview';
-import PvToast from 'primevue/toast';
 import _get from 'lodash/get';
 import _head from 'lodash/head';
 import _kebabCase from 'lodash/kebabCase';
@@ -185,6 +185,7 @@ import { CSV_EXPORT_MAX_RECORD_COUNT } from '@/constants/csvExport';
 import { TOAST_SEVERITIES, TOAST_DEFAULT_LIFE_DURATION } from '@/constants/toasts';
 import RoarDataTable from '@/components/RoarDataTable.vue';
 import PvFloatLabel from 'primevue/floatlabel';
+import AddGroupModal from '@/components/modals/AddGroupModal.vue'
 
 const router = useRouter();
 const initialized = ref(false);
@@ -213,13 +214,10 @@ const clearSearch = () => {
   searchQuery.value = '';
   sanitizedSearchString.value = '';
 };
+const isAddGroupModalVisible = ref(false)
 
 const addUsers = () => {
   router.push({ name: 'Add Users' });
-};
-
-const newGroup = () => {
-  router.push({ name: 'CreateGroup' });
 };
 
 const authStore = useAuthStore();
@@ -540,19 +538,19 @@ const filteredTableData = computed(() => {
   if (!tableData.value || !sanitizedSearchString.value) {
     return tableData.value;
   }
-  
+
   const query = sanitizedSearchString.value.toLowerCase().trim();
   return tableData.value.filter(item => {
     // Filter by name
     if (item.name && item.name.toLowerCase().includes(query)) {
       return true;
     }
-    
+
     // Filter by tags if they exist
     if (item.tags && Array.isArray(item.tags)) {
       return item.tags.some(tag => tag.toLowerCase().includes(query));
     }
-    
+
     return false;
   });
 });

--- a/src/pages/tests/ListGroups.test.js
+++ b/src/pages/tests/ListGroups.test.js
@@ -91,16 +91,15 @@ describe('ListGroups.vue', () => {
     }
   });
 
-  it('should redirect users to the page for creating groups', () => {
+  it('should turn AddGroupModal visible after clicking Add Group button', () => {
     const wrapper = mount(ListGroups, mountOptions);
     const addGroupBtn = wrapper.find('[data-testid="add-group-btn"]');
 
     expect(addGroupBtn.exists()).toBe(true);
+    expect(wrapper.vm.isAddGroupModalVisible).toBe(false);
 
     addGroupBtn.trigger('click');
-
-    expect(routerPush).toHaveBeenCalledTimes(1);
-    expect(routerPush).toHaveBeenCalledWith({ name: 'CreateGroup' });
+    expect(wrapper.vm.isAddGroupModalVisible).toBe(true);
   });
 
   it('should redirect users to the page for creating users', () => {


### PR DESCRIPTION
## Proposed changes

I converted the Add Group page into a modal. The page still exists, but I can remove it in a separate ticket after this gets approved.

**Adding a site**
https://github.com/user-attachments/assets/ac1cbdf3-2c47-40b6-a55e-1e4abe2e2d22

**Adding a school**
https://github.com/user-attachments/assets/4ceaee3a-ac74-47e2-9b61-c3ea55b4fa51

**Adding a class**
https://github.com/user-attachments/assets/5828f336-8ecb-4171-8039-a4d696bbfcf0

**Adding a cohort**
https://github.com/user-attachments/assets/8a0c58f8-e4bd-4c68-adeb-522c4150915a

**Validation and form resetting**
https://github.com/user-attachments/assets/596f1928-53ad-4c46-a42a-df3536b10c92


## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
