### PR TITLE
Fix tasks sometimes starting without birthdate

### DIFF
--- a/src/components/tasks/TaskLevante.vue
+++ b/src/components/tasks/TaskLevante.vue
@@ -75,9 +75,13 @@ onBeforeUnmount(() => {
 });
 
 watch(
-  [isFirekitInit, isLoadingUserData],
-  async ([newFirekitInitValue, newLoadingUserData]) => {
-    if (newFirekitInitValue && !newLoadingUserData && !taskStarted.value) {
+  [isFirekitInit, isLoadingUserData, userData],
+  async ([newFirekitInitValue, isLoadingUserData]) => {
+    const birthMonth = _get(userData.value, 'birthMonth');
+    const birthYear = _get(userData.value, 'birthYear');
+    const ageDataDefined = birthMonth !== undefined && birthYear !== undefined
+    
+    if (newFirekitInitValue && !isLoadingUserData && ageDataDefined && !taskStarted.value) {
       taskStarted.value = true;
       const { selectedAdmin } = storeToRefs(gameStore);
       await startTask(selectedAdmin);


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug that was causing the tasks to start with `undefined` values for `birthMonth` and `birthYear`, which prevented the downward extension version of a LEVANTE task from running for younger users. Rather than only checking for `isLoading=false` returned from the query, this now checks for actual birth date data before proceeding. 

## Types of changes

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
