### PR TITLE
Feat #429 Add delay to show tooltips

### DIFF
--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -53,7 +53,7 @@
             <span>{{ tasksDictionary[assessmentId]?.name ?? assessmentId }}</span>
             <span
               v-if="showParams"
-              v-tooltip.top="'View parameters'"
+              v-tooltip.top="tooltip('View parameters')"
               class="pi pi-info-circle cursor-pointer ml-1"
               style="font-size: 0.8rem"
               @click="toggleParams($event, assessmentId)"
@@ -115,7 +115,7 @@
                 class="no-underline text-black"
               >
                 <PvButton
-                  v-tooltip.top="'See completion details'"
+                  v-tooltip.top="tooltip('See completion details')"
                   class="m-0 bg-transparent text-bluegray-500 shadow-none border-none p-0 border-round"
                   style="color: var(--primary-color) !important"
                   severity="secondary"
@@ -140,7 +140,7 @@
                 class="no-underline"
               >
                 <PvButton
-                  v-tooltip.top="'See Scores'"
+                  v-tooltip.top="tooltip('See Scores')"
                   class="m-0 mr-1 surface-0 text-bluegray-500 shadow-1 border-none p-2 border-round hover:surface-100"
                   style="height: 2.5rem; color: var(--primary-color) !important"
                   severity="secondary"
@@ -188,7 +188,7 @@ import useDeleteAdministrationMutation from '@/composables/mutations/useDeleteAd
 import { SINGULAR_ORG_TYPES } from '@/constants/orgTypes';
 import { FIRESTORE_COLLECTIONS } from '@/constants/firebase';
 import { TOAST_SEVERITIES, TOAST_DEFAULT_LIFE_DURATION } from '@/constants/toasts';
-import { isLevante } from '@/helpers';
+import { isLevante, tooltip } from '@/helpers';
 
 interface Assessment {
   taskId: string;

--- a/src/components/ConsentPicker.vue
+++ b/src/components/ConsentPicker.vue
@@ -50,7 +50,7 @@
         </div>
         <h3 class="mt-5">Additional Data Collection</h3>
         <div
-          v-tooltip.top="!disableIfNotDefault ? tooltip : ''"
+          v-tooltip.top="tooltip(!disableIfNotDefault ? tooltipMessage : '')"
           :class="[
             'border-solid border-round border-1 border-black-alpha-30 mt-2',
             { 'opacity-80 surface-200 mt-2': !disableIfNotDefault },
@@ -77,7 +77,7 @@
           </div>
         </div>
         <div
-          v-tooltip.top="!disableIfNotDefault ? tooltip : ''"
+          v-tooltip.top="tooltip(!disableIfNotDefault ? tooltipMessage : '')"
           :class="[
             'border-solid border-round border-1 border-black-alpha-30 mt-2',
             { 'opacity-80 surface-200 mt-2': !disableIfNotDefault },
@@ -104,7 +104,7 @@
           </div>
         </div>
         <div
-          v-tooltip.top="!disableIfNotDefault ? tooltip : ''"
+          v-tooltip.top="tooltip(!disableIfNotDefault ? tooltipMessage : '')"
           :class="[
             'border-solid border-round border-1 border-black-alpha-30 mt-2',
             { 'opacity-80 surface-200 mt-2': !disableIfNotDefault },
@@ -280,6 +280,7 @@ import PvRadioButton from 'primevue/radiobutton';
 import PvFieldset from 'primevue/fieldset';
 import { useAuthStore } from '@/store/auth';
 import useLegalDocsQuery from '@/composables/queries/useLegalDocsQuery';
+import { tooltip } from '@/helpers';
 
 interface DefaultParam {
   name: string;
@@ -372,7 +373,7 @@ let selectedAssent = ref<LegalDoc | null>(null);
 const knowWhatIWant = ref<boolean>(false);
 const decision = ref<string>('');
 const disableIfNotDefault = ref<boolean>(false);
-const tooltip = ref<string>('Please check the "Default Data Collection Values" first');
+const tooltipMessage = ref<string>('Please check the "Default Data Collection Values" first');
 
 let result: Result = {
   consent: [],

--- a/src/components/EditUsersForm.vue
+++ b/src/components/EditUsersForm.vue
@@ -4,7 +4,7 @@
       <div class="form-field">
         <label :class="{ 'font-light uppercase text-sm': !editMode }"
           >Date of Birth
-          <span v-if="localUserType === 'student'" v-tooltip.top="'Required'" class="required">*</span></label
+          <span v-if="localUserType === 'student'" v-tooltip.top="tooltip('Required')" class="required">*</span></label
         >
         <div v-if="!editMode" :class="{ 'text-xl': !editMode }">
           {{ userDobString }}
@@ -21,7 +21,8 @@
 
       <div class="form-field">
         <label :class="{ 'font-light uppercase text-sm': !editMode }"
-          >Grade <span v-if="localUserType === 'student'" v-tooltip.top="'Required'" class="required">*</span></label
+          >Grade
+          <span v-if="localUserType === 'student'" v-tooltip.top="tooltip('Required')" class="required">*</span></label
         >
         <div v-if="!editMode" :class="{ 'text-xl': !editMode }">
           {{ userData?.studentData?.grade ?? 'None' }}
@@ -36,11 +37,15 @@
       <div v-if="isSuperAdmin">
         <div>
           <PvCheckbox v-model="localUserData.testData" binary />
-          <label class="ml-2">Test Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label>
+          <label class="ml-2"
+            >Test Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
+          >
         </div>
         <div>
           <PvCheckbox v-model="localUserData.demoData" binary />
-          <label class="ml-2">Demo Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label>
+          <label class="ml-2"
+            >Demo Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
+          >
         </div>
       </div>
     </div>
@@ -150,7 +155,7 @@
         <div>
           <PvCheckbox v-if="editMode" v-model="localUserData.testData" binary class="mr-2" />
           <label :class="{ 'font-light uppercase text-sm': !editMode }"
-            >Test Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label
+            >Test Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
           >
           <div v-if="!editMode" :class="{ 'text-xl': !editMode }">
             {{ localUserData.testData ? 'Yes' : 'No' }}
@@ -159,7 +164,7 @@
         <div>
           <PvCheckbox v-if="editMode" v-model="localUserData.demoData" binary class="mr-2" />
           <label :class="{ 'font-light uppercase text-sm': !editMode }"
-            >Demo Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label
+            >Demo Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
           >
           <div v-if="!editMode" :class="{ 'text-xl': !editMode }">
             {{ localUserData.demoData ? 'Yes' : 'No' }}
@@ -225,6 +230,7 @@ import PvCheckbox from 'primevue/checkbox';
 import PvSelect from 'primevue/select';
 import PvInputText from 'primevue/inputtext';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
+import { tooltip } from '@/helpers';
 
 interface Name {
   first?: string | null;

--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -23,7 +23,7 @@
         <PvFloatLabel v-if="props.allowColumnSelection">
           <PvMultiSelect
             id="ms-columns"
-            v-tooltip.top="'Show and hide columns'"
+            v-tooltip.top="tooltip('Show and hide columns')"
             :model-value="selectedColumns"
             :options="inputColumns"
             option-label="header"
@@ -132,7 +132,7 @@
           >
             <template #header>
               <div
-                v-tooltip.top="`${toolTipByHeader(col.header)}`"
+                v-tooltip.top="tooltip(`${toolTipByHeader(col.header)}`)"
                 :style="[
                   toolTipByHeader(col.header).length > 0
                     ? 'text-decoration: underline dotted #0000CD; text-underline-offset: 3px'
@@ -170,7 +170,7 @@
               <div v-else-if="col.link">
                 <router-link :to="{ name: col.routeName, params: colData.routeParams }">
                   <PvButton
-                    v-tooltip.right="colData.tooltip"
+                    v-tooltip.right="tooltip(colData.tooltip)"
                     severity="secondary"
                     text
                     class="border border-round surface-200 p-2 hover:surface-500"
@@ -203,7 +203,11 @@
                     @click="$emit(col.eventName, colData)"
                   />
                   <span
-                    v-if="col.eventName === 'assignments-button' && colData.assignmentCount !== undefined && colData.assignmentCount !== null"
+                    v-if="
+                      col.eventName === 'assignments-button' &&
+                      colData.assignmentCount !== undefined &&
+                      colData.assignmentCount !== null
+                    "
                     class="font-semibold text-sm ml-2"
                   >
                     {{ colData.assignmentCount }}
@@ -402,6 +406,7 @@ import _startCase from 'lodash/startCase';
 import { supportLevelColors, progressTags } from '@/helpers/reports';
 import SkeletonTable from '@/components/SkeletonTable.vue';
 import TableScoreTag from '@/components/reports/TableScoreTag.vue';
+import { tooltip } from '@/helpers';
 
 /*
 Using the DataTable

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -84,7 +84,7 @@
 
       <div class="sidebar__nav">
         <div
-          v-tooltip.right="'Current'"
+          v-tooltip.right="tooltip('Current')"
           :class="`sidebar__nav-link --${ASSIGNMENT_STATUSES.CURRENT} ${selectedStatusCurrent ? '--active' : ''}`"
           @click="() => onClickSideBarNavLink(ASSIGNMENT_STATUSES.CURRENT)"
         >
@@ -92,7 +92,7 @@
         </div>
 
         <div
-          v-tooltip.right="'Upcoming'"
+          v-tooltip.right="tooltip('Upcoming')"
           :class="`sidebar__nav-link --${ASSIGNMENT_STATUSES.UPCOMING} ${selectedStatusUpcoming ? '--active' : ''}`"
           @click="() => onClickSideBarNavLink(ASSIGNMENT_STATUSES.UPCOMING)"
         >
@@ -100,7 +100,7 @@
         </div>
 
         <div
-          v-tooltip.right="'Past'"
+          v-tooltip.right="tooltip('Past')"
           :class="`sidebar__nav-link --${ASSIGNMENT_STATUSES.PAST} ${selectedStatusPast ? '--active' : ''}`"
           @click="() => onClickSideBarNavLink(ASSIGNMENT_STATUSES.PAST)"
         >
@@ -117,6 +117,7 @@ import { useAssignmentsStore } from '@/store/assignments';
 import { AdministrationType } from '@levante-framework/levante-zod';
 import { computed, ref } from 'vue';
 import AssignmentCard from './assignments/AssignmentCard.vue';
+import { tooltip } from '@/helpers';
 
 interface Props {
   currentAssignments?: AdministrationType[];

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -18,7 +18,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary ml-2"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'View parameters'"
+              v-tooltip.top="tooltip('View parameters')"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
@@ -27,12 +27,26 @@
               <PvChip class="bg-primary text-white h-2rem" label="CAT" />
             </div>
             <div v-if="variant?.variant?.params?.language" class="flex align-items-center">
-              <PvChip :class="getLanguageInfo(variant.variant.params.language)?.isLegacy ? 'bg-orange-500 text-white h-2rem' : 'bg-green-500 text-white h-2rem'">
+              <PvChip
+                :class="
+                  getLanguageInfo(variant.variant.params.language)?.isLegacy
+                    ? 'bg-orange-500 text-white h-2rem'
+                    : 'bg-green-500 text-white h-2rem'
+                "
+              >
                 <template #default>
                   <div class="flex align-items-center gap-1">
-                    <span v-if="getLanguageInfo(variant.variant.params.language)" :class="`fi fi-${getLanguageInfo(variant.variant.params.language)?.flagCode}`" style="font-size: 0.8rem;"></span>
-                    <span>{{ getLanguageInfo(variant.variant.params.language)?.displayName || variant.variant.params.language }}</span>
-                    <small v-if="getLanguageInfo(variant.variant.params.language)?.isLegacy" class="ml-1">(legacy)</small>
+                    <span
+                      v-if="getLanguageInfo(variant.variant.params.language)"
+                      :class="`fi fi-${getLanguageInfo(variant.variant.params.language)?.flagCode}`"
+                      style="font-size: 0.8rem"
+                    ></span>
+                    <span>{{
+                      getLanguageInfo(variant.variant.params.language)?.displayName || variant.variant.params.language
+                    }}</span>
+                    <small v-if="getLanguageInfo(variant.variant.params.language)?.isLegacy" class="ml-1"
+                      >(legacy)</small
+                    >
                   </div>
                 </template>
               </PvChip>
@@ -51,7 +65,7 @@
               class="p-0 surface-hover border-none border-circle -rotate-45 hover:text-100 hover:bg-primary"
               @click="visible = true"
               ><i
-                v-tooltip.top="'Click to expand'"
+                v-tooltip.top="tooltip('Click to expand')"
                 class="pi pi-arrows-h border-circle p-2 text-primary hover:text-100"
               ></i
             ></PvButton>
@@ -122,7 +136,7 @@
             class="p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary"
             @click="toggle($event)"
             ><i
-              v-tooltip.top="'View parameters'"
+              v-tooltip.top="tooltip('View parameters')"
               class="pi pi-info-circle text-primary p-1 border-circle hover:text-100"
             ></i
           ></PvButton>
@@ -147,7 +161,7 @@
             class="p-0 surface-hover border-none border-circle -rotate-45 hover:text-100 hover:bg-primary"
             @click="visible = true"
             ><i
-              v-tooltip.top="'Click to expand'"
+              v-tooltip.top="tooltip('Click to expand')"
               class="pi pi-arrows-h border-circle p-2 text-primary hover:text-100"
             ></i
           ></PvButton>
@@ -289,6 +303,7 @@ import PvPopover from 'primevue/popover';
 import PvTag from 'primevue/tag';
 import EditVariantDialog from '@/components/EditVariantDialog.vue';
 import { getLanguageInfo } from '@/helpers/languageDiscovery';
+import { tooltip } from '@/helpers';
 
 interface Condition {
   field: string;

--- a/src/components/assignments/AssignmentCard.vue
+++ b/src/components/assignments/AssignmentCard.vue
@@ -24,7 +24,7 @@
         <div
           v-for="task in props?.data?.assessments"
           :key="task?.taskId"
-          v-tooltip.top="task?.variantName"
+          v-tooltip.top="tooltip(task?.variantName)"
           class="assignment-card__task"
         ></div>
       </div>
@@ -38,6 +38,7 @@
 
 <script lang="ts" setup>
 import { ASSIGNMENT_STATUSES } from '@/constants';
+import { tooltip } from '@/helpers';
 import { AdministrationType } from '@levante-framework/levante-zod';
 import { format } from 'date-fns';
 

--- a/src/components/modals/EditUsers.vue
+++ b/src/components/modals/EditUsers.vue
@@ -35,7 +35,9 @@
             <div class="form-field">
               <label
                 >Date of Birth
-                <span v-if="localUserType === 'student'" v-tooltip.top="'Required'" class="required">*</span></label
+                <span v-if="localUserType === 'student'" v-tooltip.top="tooltip('Required')" class="required"
+                  >*</span
+                ></label
               >
               <PvDatePicker
                 v-model="localUserData.studentData.dob"
@@ -49,7 +51,9 @@
             <div class="form-field">
               <label
                 >Grade
-                <span v-if="localUserType === 'student'" v-tooltip.top="'Required'" class="required">*</span></label
+                <span v-if="localUserType === 'student'" v-tooltip.top="tooltip('Required')" class="required"
+                  >*</span
+                ></label
               >
               <PvInputText
                 v-model="localUserData.studentData.grade"
@@ -63,13 +67,13 @@
               <div>
                 <PvCheckbox v-model="localUserData.testData" binary />
                 <label class="ml-2"
-                  >Test Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label
+                  >Test Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
                 >
               </div>
               <div>
                 <PvCheckbox v-model="localUserData.demoData" binary />
                 <label class="ml-2"
-                  >Demo Data? <span v-tooltip.top="'Super Admin Only'" class="admin-only">*</span></label
+                  >Demo Data? <span v-tooltip.top="tooltip('Super Admin Only')" class="admin-only">*</span></label
                 >
               </div>
             </div>
@@ -214,6 +218,7 @@ import PvDialog from 'primevue/dialog';
 import PvSelect from 'primevue/select';
 import PvInputText from 'primevue/inputtext';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
+import { tooltip } from '@/helpers';
 
 interface StudentData {
   dob: Date | null;

--- a/src/components/reports/TableScoreTag.vue
+++ b/src/components/reports/TableScoreTag.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     v-if="(_get(colData, col.field) != undefined || _get(colData, 'optional')) && col.emptyTag !== true"
-    v-tooltip.right="`${returnScoreTooltip(colData, col.field)}`"
+    v-tooltip.right="tooltip(`${returnScoreTooltip(colData, col.field)}`)"
   >
     <PvTag
       :value="_get(colData, col.field)"
-      :style="`background-color: ${_get(colData, col.tagColor)}; min-width: 2rem; 
+      :style="`background-color: ${_get(colData, col.tagColor)}; min-width: 2rem;
         ${returnScoreTooltip(colData, col.field)?.length > 0 && 'outline: 1px dotted #0000CD; outline-offset: 3px'};
         font-weight: bold;
         color: ${_get(colData, col.tagColor) === '#A4DDED' ? 'black' : 'white'};
@@ -13,7 +13,7 @@
       rounded
     />
   </div>
-  <div v-else-if="col.emptyTag" v-tooltip.right="`${returnScoreTooltip(colData, col.field)}`">
+  <div v-else-if="col.emptyTag" v-tooltip.right="tooltip(`${returnScoreTooltip(colData, col.field)}`)">
     <div
       class="circle"
       :style="`background-color: ${_get(colData, col.tagColor)}; color: ${
@@ -35,6 +35,7 @@ import {
   scoredTasks,
   includedValidityFlags,
 } from '@/helpers/reports';
+import { tooltip } from '@/helpers';
 
 defineProps({
   colData: {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -231,19 +231,11 @@ export const normalizeToLowercase = (str = ''): string =>
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '');
 
-export const tooltip = (param: TooltipOptions | string): TooltipOptions => {
+export const tooltip = (value: string, options?: TooltipOptions): TooltipOptions => {
   const defaultOptions = {
-    autoHide: true,
-    disabled: false,
     hideDelay: 0,
     showDelay: 1500,
-    unstyled: false,
-    value: '',
   } as TooltipOptions;
 
-  if (typeof param === 'string') {
-    return { ...defaultOptions, value: param };
-  }
-
-  return { ...defaultOptions, ...param };
+  return { ...defaultOptions, ...options, value };
 };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,6 +3,7 @@ import _fromPairs from 'lodash/fromPairs';
 import _invert from 'lodash/invert';
 import _toPairs from 'lodash/toPairs';
 import * as Papa from 'papaparse';
+import { TooltipOptions } from 'primevue/tooltip';
 
 export const isLevante: boolean = import.meta.env.VITE_LEVANTE === 'TRUE';
 export const isEmulator: boolean = (import.meta.env.VITE_EMULATOR as string) === 'TRUE';
@@ -229,3 +230,20 @@ export const normalizeToLowercase = (str = ''): string =>
     .toLowerCase()
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '');
+
+export const tooltip = (param: TooltipOptions | string): TooltipOptions => {
+  const defaultOptions = {
+    autoHide: true,
+    disabled: false,
+    hideDelay: 0,
+    showDelay: 1500,
+    unstyled: false,
+    value: '',
+  } as TooltipOptions;
+
+  if (typeof param === 'string') {
+    return { ...defaultOptions, value: param };
+  }
+
+  return { ...defaultOptions, ...param };
+};

--- a/src/pages/ProgressReport.vue
+++ b/src/pages/ProgressReport.vue
@@ -32,7 +32,7 @@
             <div class="uppercase text-sm text-gray-600">VIEW</div>
             <PvSelectButton
               v-model="reportView"
-              v-tooltip.top="tooltip('View different report')"
+              v-tooltip.top="tooltip('View different report', { showDelay: 0 })"
               :options="reportViews"
               option-disabled="constant"
               :allow-empty="false"

--- a/src/pages/ProgressReport.vue
+++ b/src/pages/ProgressReport.vue
@@ -32,7 +32,7 @@
             <div class="uppercase text-sm text-gray-600">VIEW</div>
             <PvSelectButton
               v-model="reportView"
-              v-tooltip.top="'View different report'"
+              v-tooltip.top="tooltip('View different report')"
               :options="reportViews"
               option-disabled="constant"
               :allow-empty="false"
@@ -191,7 +191,7 @@ import { exportCsv } from '@/helpers/query/utils';
 import { taskDisplayNames, gradeOptions } from '@/helpers/reports';
 import { getTitle } from '@/helpers/query/administrations';
 import { setBarChartData, setBarChartOptions } from '@/helpers/plotting';
-import { isLevante } from '@/helpers';
+import { isLevante, tooltip } from '@/helpers';
 import { APP_ROUTES } from '@/constants/routes';
 import { SINGULAR_ORG_TYPES } from '@/constants/orgTypes';
 import RoarDataTable from '@/components/RoarDataTable.vue';


### PR DESCRIPTION
## Proposed changes

The current lib (primevue) doesn't have a built-in way to set props for the tooltip globally, so I created a helper function to return an instance of the tooltip with some custom default options.


https://github.com/user-attachments/assets/72094897-5ccf-4ec2-a0a2-e6a599c03146



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
