### PR TITLE
Feat #537 Make all assignment cards clickable

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -26,7 +26,7 @@
                 :key="assignment?.id"
                 :data="assignment"
                 :is-active="assignmentsStore.selectedAssignment?.id === assignment?.id"
-                :status="selectedStatus"
+                :status="ASSIGNMENT_STATUSES.CURRENT"
                 @click="onClickAssignment"
               />
             </ul>
@@ -46,7 +46,8 @@
                 :key="assignment?.id"
                 :data="assignment"
                 :is-active="assignmentsStore.selectedAssignment?.id === assignment?.id"
-                :status="selectedStatus"
+                :status="ASSIGNMENT_STATUSES.UPCOMING"
+                @click="onClickAssignment"
               />
             </ul>
             <div v-else class="assignment-group__empty">No upcoming assignments were found</div>
@@ -65,7 +66,8 @@
                 :key="assignment?.id"
                 :data="assignment"
                 :is-active="assignmentsStore.selectedAssignment?.id === assignment?.id"
-                :status="selectedStatus"
+                :status="ASSIGNMENT_STATUSES.PAST"
+                @click="onClickAssignment"
               />
             </ul>
             <div v-else class="assignment-group__empty">No past assignments were found</div>
@@ -142,10 +144,12 @@ const numOfCurrentAssignments = computed(() => {
   const length = props?.currentAssignments?.length;
   return length > 0 ? length.toString().padStart(2, '0') : '--';
 });
+
 const numOfPastAssignments = computed(() => {
   const length = props?.pastAssignments?.length;
   return length > 0 ? length.toString().padStart(2, '0') : '--';
 });
+
 const numOfUpcomingAssignments = computed(() => {
   const length = props?.upcomingAssignments?.length;
   return length > 0 ? length.toString().padStart(2, '0') : '--';
@@ -203,10 +207,10 @@ const onClickSideBarToggleBtn = () => {
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   width: var(--sidebar-width);
   height: 100%;
-  padding: 0.5rem 0;
+  padding: 0.75rem 0;
   background: white;
   border-right: 1px solid var(--surface-d);
   position: relative;
@@ -217,8 +221,8 @@ const onClickSideBarToggleBtn = () => {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   border-radius: 0.75rem;
   color: var(--gray-600);
   cursor: pointer;
@@ -247,7 +251,7 @@ const onClickSideBarToggleBtn = () => {
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .sidebar__nav-link {
@@ -293,7 +297,7 @@ const onClickSideBarToggleBtn = () => {
   width: var(--sidebar-panel-width);
   height: 100%;
   margin: 0;
-  padding: 0.5rem 0;
+  padding: 0.65rem 0;
   background: white;
   position: absolute;
   top: 0;

--- a/src/components/assignments/AssignmentCard.vue
+++ b/src/components/assignments/AssignmentCard.vue
@@ -1,8 +1,6 @@
 <template>
   <div
-    :class="`assignment-card ${props.isActive ? '--active' : ''} ${
-      props.status === ASSIGNMENT_STATUSES.CURRENT ? '--clickable' : ''
-    }`"
+    :class="`assignment-card ${props.isActive ? '--active' : ''}`"
     @click="props.onClick && props.onClick(props.data, props.status)"
   >
     <div class="assignment-card__content">
@@ -63,6 +61,7 @@ const props = defineProps<Props>();
   padding: 0.75rem;
   border: 1px solid var(--surface-d);
   border-radius: 0.75rem;
+  cursor: pointer;
 
   &.--active {
     background: rgba(var(--bright-yellow-rgb), 0.1);
@@ -75,10 +74,6 @@ const props = defineProps<Props>();
     .assignment-card__task {
       background: rgba(var(--bright-yellow-rgb), 0.5);
     }
-  }
-
-  &.--clickable {
-    cursor: pointer;
   }
 }
 

--- a/src/components/tests/AssignmentCard.test.js
+++ b/src/components/tests/AssignmentCard.test.js
@@ -136,20 +136,6 @@ describe('AssignmentCard.vue', () => {
       expect(wrapper.find('.pi.pi-lock').exists()).toBe(false);
       expect(wrapper.find('.pi.pi-check-circle').exists()).toBe(false);
     });
-
-    it('should apply correct CSS classes based on status', () => {
-      const wrapper = mount(AssignmentCard, mountOptions({ status: 'current' }));
-      const card = wrapper.find('.assignment-card');
-
-      expect(card.classes()).toContain('--clickable');
-    });
-
-    it('should not apply clickable class for non-current assignments', () => {
-      const wrapper = mount(AssignmentCard, mountOptions({ status: 'upcoming' }));
-      const card = wrapper.find('.assignment-card');
-
-      expect(card.classes()).not.toContain('--clickable');
-    });
   });
 
   describe('Active State Styling', () => {
@@ -254,20 +240,6 @@ describe('AssignmentCard.vue', () => {
       const card = wrapper.find('.assignment-card');
 
       expect(card.classes()).toContain('--active');
-    });
-
-    it('should apply clickable class for current status', () => {
-      const wrapper = mount(AssignmentCard, mountOptions({ status: 'current' }));
-      const card = wrapper.find('.assignment-card');
-
-      expect(card.classes()).toContain('--clickable');
-    });
-
-    it('should not apply clickable class for non-current status', () => {
-      const wrapper = mount(AssignmentCard, mountOptions({ status: 'upcoming' }));
-      const card = wrapper.find('.assignment-card');
-
-      expect(card.classes()).not.toContain('--clickable');
     });
   });
 


### PR DESCRIPTION
## Proposed changes

I added the `onClick` prop to every assignment card, so the user can select `current`, `upcoming` and `past` assignments.


https://github.com/user-attachments/assets/025df171-3c86-4be3-a280-cf7cc62e4e25



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
