### PR TITLE
fix(): Removing the circular objects and sending explicit arguments

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -354,7 +354,10 @@ router.beforeEach(async (to: RouteLocationNormalized, from: RouteLocationNormali
 
 // PostHog pageview tracking
 router.afterEach((to, from) => {
-  logger.capture('pageview', { to, from });
+  logger.capture('pageview', {
+    to: { name: to.name, path: to.path },
+    from: { name: from.name, path: from.path }
+  });
 });
 
 export default router;


### PR DESCRIPTION
During login the vue router fires about 4 times!! Since we were sending the full router vue objecs (to and from) which are large circular jsons. Calling them multiple times over a short period of time was causing the bug in posthog. Now we extract what we want to send and it fixes the issue.

We should however look into why the router is called so many times for login and logout as a separate ticket.

## Proposed changes

<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
