### PR TITLE
Feat #632 Change user feedback after creating assignment

### DIFF
--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -587,26 +587,28 @@ const submit = async () => {
     },
   };
 
-  if (props.adminId) args.administrationId = props.adminId;
+  if (props.adminId) {
+    args.administrationId = props.adminId;
+  } else {
+    const { data: assignmentExist } = await doesAssignmentExist();
 
-  const { data: assignmentExist } = await doesAssignmentExist();
+    if (assignmentExist === null) {
+      return toast.add({
+        severity: TOAST_SEVERITIES.ERROR,
+        summary: 'Error',
+        detail: 'Failed to check for duplicate assignment names. Try again or use a different name.',
+        life: TOAST_DEFAULT_LIFE_DURATION,
+      });
+    }
 
-  if (assignmentExist === null) {
-    return toast.add({
-      severity: TOAST_SEVERITIES.ERROR,
-      summary: 'Error',
-      detail: 'Failed to check for duplicate assignment names. Try again or use a different name.',
-      life: TOAST_DEFAULT_LIFE_DURATION,
-    });
-  }
-
-  if (assignmentExist) {
-    return toast.add({
-      severity: 'error',
-      summary: 'Assignment Creation Error',
-      detail: 'An assignment with that name already exists.',
-      life: TOAST_DEFAULT_LIFE_DURATION,
-    });
+    if (assignmentExist) {
+      return toast.add({
+        severity: 'error',
+        summary: 'Assignment Creation Error',
+        detail: 'An assignment with that name already exists.',
+        life: TOAST_DEFAULT_LIFE_DURATION,
+      });
+    }
   }
 
   upsertAdministration(args, {
@@ -614,7 +616,9 @@ const submit = async () => {
       toast.add({
         severity: TOAST_SEVERITIES.SUCCESS,
         summary: 'Success',
-        detail: props.adminId ? 'Assignment updated' : 'Assignment created',
+        detail: props.adminId
+          ? 'Your assignment edits are being processed. Please check back in a few minutes.'
+          : 'Your new assignment is being processed. Please check back in a few minutes.',
         life: TOAST_DEFAULT_LIFE_DURATION,
       });
 


### PR DESCRIPTION
## Proposed changes

I changed the user feedback after creating/editing an assignment.

Notes: I took the opportunity to fix a small issue ([#629](https://github.com/levante-framework/levante-dashboard/issues/629)) that was forcing the user to rename the assignment when editing it.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
