### PR TITLE
remove hostile attribution from task picker

### DIFF
--- a/src/components/GameTabs.vue
+++ b/src/components/GameTabs.vue
@@ -345,7 +345,6 @@ const levanteTasks: string[] = [
   'mefs',
   'roarInference',
   'vocab',
-  'hostileAttribution',
 ];
 
 const roarTasks: string[] = [

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -255,7 +255,7 @@ const groupedTasks: Record<string, string[]> = {
   Math: ['Math'],
   Reasoning: ['Pattern Matching'],
   'Spatial Cognition': ['Shape Rotation'],
-  'Social Cognition': ['Stories', 'On Purpose or by Accident?'],
+  'Social Cognition': ['Stories'],
   Attitudes: ['Survey'],
 };
 

--- a/src/translations/de/de-componentTranslations.json
+++ b/src/translations/de/de-componentTranslations.json
@@ -130,9 +130,7 @@
       "taskNotYetAvailable": "Noch nicht verfügbar",
       "paDescription": "Den Klang in den Wörtern identifizieren.",
       "sreDescription": "Lies die Sätze so schnell wie möglich und entscheide, ob sie wahr oder falsch sind.",
-      "swrDescription": "Die Wörter werden schnell auf dem Bildschirm erscheinen. Entscheide, ob sie echt oder erfunden sind.",
-      "hostileAttributionName": "Mit Absicht oder durch Zufall?",
-      "hostileAttributionDescription": "Hör dir die Wörter an und wähle das passende Bild dazu aus."
+      "swrDescription": "Die Wörter werden schnell auf dem Bildschirm erscheinen. Entscheide, ob sie echt oder erfunden sind."
     },
     "navbar": {
       "greeting": "Hallo",

--- a/src/translations/en/us/en-US-componentTranslations.json
+++ b/src/translations/en/us/en-US-componentTranslations.json
@@ -130,9 +130,7 @@
       "taskNotYetAvailable": "Not available yet",
       "paDescription": "Identify the sound in the words.",
       "sreDescription": "Read the sentences as quickly as you can and decide if they are true or false.",
-      "swrDescription": "The words will appear quickly on the screen. Decide if they are real or made-up.",
-      "hostileAttributionName": "On Purpose or by Accident?",
-      "hostileAttributionDescription": "Listen to the stories and answer the questions."
+      "swrDescription": "The words will appear quickly on the screen. Decide if they are real or made-up."
     },
     "navbar": {
       "greeting": "Hi",

--- a/src/translations/es/co/es-CO-componentTranslations.json
+++ b/src/translations/es/co/es-CO-componentTranslations.json
@@ -130,9 +130,7 @@
       "taskNotYetAvailable": "Aún no está disponible",
       "paDescription": "Identificar el sonido en las palabras",
       "sreDescription": "Lee las oraciones tan rápido como puedas y decide si son verdaderas o falsas.",
-      "swrDescription": "Las palabras aparecerán rápidamente en la pantalla. Decide si son reales o inventadas.",
-      "hostileAttributionName": "¿A Propósito o por Accidente?",
-      "hostileAttributionDescription": "Escucha las historias y responde a las preguntas."
+      "swrDescription": "Las palabras aparecerán rápidamente en la pantalla. Decide si son reales o inventadas."
     },
     "navbar": {
       "greeting": "¡Hola!",

--- a/src/translations/es/es-componentTranslations.json
+++ b/src/translations/es/es-componentTranslations.json
@@ -130,9 +130,7 @@
       "taskNotYetAvailable": "Aún no está disponible",
       "paDescription": "Identificar el sonido en las palabras",
       "sreDescription": "Lee las oraciones tan rápido como puedas y decide si son verdaderas o falsas.",
-      "swrDescription": "Las palabras aparecerán rápidamente en la pantalla. Decide si son reales o inventadas.",
-      "hostileAttributionName": "¿A Propósito o por Accidente?",
-      "hostileAttributionDescription": "Escucha las historias y responde a las preguntas."
+      "swrDescription": "Las palabras aparecerán rápidamente en la pantalla. Decide si son reales o inventadas."
     },
     "navbar": {
       "greeting": "¡Hola!",


### PR DESCRIPTION
## Proposed changes

This PR reverts the changes that added hostile attribution to the task picker, since we don't want this to be visible on prod for now.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [x] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
