### PR TITLE
Bug #729 Site selector is not filtering assignments on home page

### DIFF
--- a/src/composables/queries/useAdministrationsListQuery.ts
+++ b/src/composables/queries/useAdministrationsListQuery.ts
@@ -1,10 +1,8 @@
-import { computed, ref, Ref, toValue } from 'vue';
+import { computed, Ref, toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import _isEmpty from 'lodash/isEmpty';
 import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
 import { administrationPageFetcher } from '@/helpers/query/administrations';
-import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
-import useUserType from '@/composables/useUserType';
 import { ADMINISTRATIONS_LIST_QUERY_KEY } from '@/constants/queryKeys';
 import { useAuthStore } from '@/store/auth';
 import { storeToRefs } from 'pinia';
@@ -25,11 +23,7 @@ const useAdministrationsListQuery = (
   queryOptions?: UseQueryOptions,
 ): UseQueryReturnType => {
   const authStore = useAuthStore();
-  const { shouldUsePermissions, userClaims } = storeToRefs(authStore);
-  const { isUserSuperAdmin } = authStore;
-
-  // Get admin status and administation orgs.
-  const exhaustiveAdministrationOrgs = computed(() => userClaims.value?.claims?.adminOrgs);
+  const { userClaims } = storeToRefs(authStore);
 
   // Ensure all necessary data is loaded before enabling the query.
   const claimsLoaded = computed(() => !_isEmpty(userClaims?.value?.claims));
@@ -46,14 +40,7 @@ const useAdministrationsListQuery = (
   return useQuery({
     queryKey,
     queryFn: async () => {
-      const result = await administrationPageFetcher(
-        selectedDistrictId,
-        shouldUsePermissions,
-        ref(isUserSuperAdmin()),
-        exhaustiveAdministrationOrgs,
-        testAdministrationsOnly,
-        orderBy,
-      );
+      const result = await administrationPageFetcher(selectedDistrictId, testAdministrationsOnly, orderBy);
       return result.sortedAdministrations;
     },
     enabled: isQueryEnabled,
@@ -78,9 +65,6 @@ const useFullAdministrationsListQuery = (
 ): UseQueryReturnType => {
   const authStore = useAuthStore();
   const { userClaims } = storeToRefs(authStore);
-  const { isUserSuperAdmin } = authStore;
-
-  const exhaustiveAdministrationOrgs = computed(() => userClaims.value?.claims?.adminOrgs);
 
   // Ensure all necessary data is loaded before enabling the query.
   const claimsLoaded = computed(() => !_isEmpty(userClaims?.value?.claims));
@@ -96,14 +80,7 @@ const useFullAdministrationsListQuery = (
 
   return useQuery({
     queryKey,
-    queryFn: () =>
-      administrationPageFetcher(
-        selectedDistrictId,
-        isUserSuperAdmin(),
-        exhaustiveAdministrationOrgs,
-        testAdministrationsOnly,
-        orderBy,
-      ),
+    queryFn: () => administrationPageFetcher(selectedDistrictId, testAdministrationsOnly, orderBy),
     enabled: isQueryEnabled,
     ...options,
   });


### PR DESCRIPTION
## Proposed changes

I updated the administrationPageFetcher function so the site selector can filter assignments on the home page. I also removed some old-permissions-related code.


https://github.com/user-attachments/assets/43e1da99-88e9-4fc6-8b3a-e9c43791354c



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
