### PR TITLE
Replace user claims with roles for super admins check

### DIFF
--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -7,6 +7,7 @@ import posthogInstance from '@/plugins/posthog';
 import { logger } from '@/logger';
 import { RoarFirekit } from '@levante-framework/firekit';
 import { ref, type Ref } from 'vue';
+import { ROLES } from '@levante-framework/permissions-core';
 
 interface FirebaseUser {
   adminFirebaseUser: User | null;
@@ -119,7 +120,7 @@ export const useAuthStore = defineStore(
     }
 
     function isUserSuperAdmin(): boolean {
-      return Boolean(userClaims.value?.claims?.super_admin);
+      return Boolean(userData.value?.roles?.some((role) => role?.role === ROLES.SUPER_ADMIN));
     }
 
     // Actions
@@ -268,7 +269,6 @@ export const useAuthStore = defineStore(
       userClaims.value = claims;
       shouldUsePermissions.value = Boolean(claims?.claims?.useNewPermissions);
     }
-
 
     return {
       // State


### PR DESCRIPTION
## Proposed changes

As part of the new permissions feature, I updated the auth function `isUserSuperAdmin()` to use the `roles` prop within the `userData` object instead of the `userClaims` doc, which is about to be deprecated.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
