### PR TITLE
Fix Manage Administrators site filter (Issue #764)

### DIFF
--- a/src/helpers/query/administrations.js
+++ b/src/helpers/query/administrations.js
@@ -255,9 +255,6 @@ export const fetchAdminsBySite = async (siteId, siteName, db = FIRESTORE_DATABAS
         const rRole = r?.role;
         if (!rSiteId || !rRole) return false;
 
-        // Global super admins should show up under any selected site.
-        if (rSiteId === 'any' && rRole === ROLES.SUPER_ADMIN) return true;
-
         // Site-scoped roles: show admins assigned to the selected site regardless of siteName shape.
         return rSiteId === selectedSiteId && allowedSiteRoles.has(rRole);
       });


### PR DESCRIPTION
## What
When selecting a specific site on **Manage Administrators**, some pre-existing admins would disappear because the Firestore query required an *exact* match of the entire `roles[]` object (including `siteName`).

## Fix
- Fetch all admin users (using a select mask) and filter client-side by `roles.siteId` + `roles.role`, ignoring `siteName`.

## Why
Older PROD admin role entries can have missing/different `siteName` fields (or additional fields), so `ARRAY_CONTAINS` with an object literal was too strict.

## Testing
- Verified site **C-Cuskley-Test** (siteId `WrWpCTFX0v4r1gyjxvTL`) now shows expected admins when selected.
