### PR TITLE
Block redundant assignments

### DIFF
--- a/src/components/GroupPicker.vue
+++ b/src/components/GroupPicker.vue
@@ -84,7 +84,20 @@
           </div>
         </div>
       </PvScrollPanel>
+
+      <PvButton
+        v-if="hasSelectedOrgs"
+        class="w-full"
+        severity="danger"
+        size="small"
+        variant="outlined"
+        @click="onClickClearSelectionBtn"
+      >
+        Clear selection
+      </PvButton>
     </PvPanel>
+
+    <PvConfirmDialog :draggable="false" />
   </div>
 </template>
 
@@ -97,7 +110,9 @@ import { orderByDefault } from '@/helpers/query/utils';
 import { useAuthStore } from '@/store/auth';
 import _capitalize from 'lodash/capitalize';
 import { storeToRefs } from 'pinia';
+import PvButton from 'primevue/button';
 import PvChip from 'primevue/chip';
+import PvConfirmDialog from 'primevue/confirmdialog';
 import PvFloatLabel from 'primevue/floatlabel';
 import PvListbox from 'primevue/listbox';
 import PvPanel from 'primevue/panel';
@@ -108,6 +123,7 @@ import PvTabList from 'primevue/tablist';
 import PvTabPanel from 'primevue/tabpanel';
 import PvTabPanels from 'primevue/tabpanels';
 import PvTabs from 'primevue/tabs';
+import { useConfirm } from 'primevue/useconfirm';
 import { computed, reactive, ref, toRaw, watch } from 'vue';
 
 interface OrgItem {
@@ -115,6 +131,7 @@ interface OrgItem {
   name: string;
   districtId?: string;
   schoolId?: string;
+  parentOrgId?: string;
   schools?: any[];
   classes?: any[];
 }
@@ -137,6 +154,7 @@ interface Emits {
 
 const authStore = useAuthStore();
 const { currentSite } = storeToRefs(authStore);
+const confirm = useConfirm();
 
 const emit = defineEmits<Emits>();
 const props = defineProps<Props>();
@@ -144,12 +162,22 @@ const props = defineProps<Props>();
 const activeHeader = ref<string>(FIRESTORE_COLLECTIONS.DISTRICTS);
 const orderBy = ref(orderByDefault);
 const selectedSchool = ref<string | undefined>(undefined);
+const isSelectionSyncing = ref(false);
 const selectedOrgs = reactive<OrgCollection>({
   districts: [],
   schools: [],
   classes: [],
   groups: [],
   families: [],
+});
+
+const hasSelectedOrgs = computed(() => {
+  return [
+    FIRESTORE_COLLECTIONS.DISTRICTS,
+    FIRESTORE_COLLECTIONS.SCHOOLS,
+    FIRESTORE_COLLECTIONS.CLASSES,
+    FIRESTORE_COLLECTIONS.GROUPS,
+  ].some((key) => selectedOrgs[key]?.length > 0);
 });
 
 const orgHeaders = computed(() => [
@@ -225,6 +253,144 @@ const removeSelectedOrg = (orgHeader: string, selectedOrg: OrgItem) => {
   }
 };
 
+const onClickClearSelectionBtn = () => {
+  confirm.require({
+    header: 'Clear selection?',
+    message: 'Do you really want to remove all the selected groups?',
+    acceptLabel: 'Continue',
+    rejectLabel: 'Cancel',
+    rejectProps: {
+      label: 'Cancel',
+      severity: 'secondary',
+      outlined: true,
+    },
+    accept: clearSelectedOrgs,
+  });
+};
+
+// Stop component selection for user confirmation
+const syncSelection = (callback: () => void) => {
+  isSelectionSyncing.value = true;
+  callback();
+  isSelectionSyncing.value = false;
+};
+
+// Check if there is any site children (schools, classes and groups) selected
+const hasDistrictChildrenSelected = () =>
+  selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS]?.length ||
+  selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES]?.length ||
+  selectedOrgs[FIRESTORE_COLLECTIONS.GROUPS]?.length;
+
+// Check if there is any school children (classes) selected
+const hasSchoolChildrenSelected = () => selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES]?.length;
+
+const getNewSelections = (nextItems: OrgItem[], previousItems: OrgItem[]) => {
+  const previousIds = new Set(previousItems.map((org) => org.id));
+  return nextItems.filter((org) => !previousIds.has(org.id));
+};
+
+const getSchoolSelectedChildrenIds = () =>
+  new Set(
+    (selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES] ?? [])
+      .map((org) => org.schoolId)
+      .filter((schoolId): schoolId is string => !!schoolId),
+  );
+
+const getDistrictSelectedChildrenIds = () =>
+  new Set(
+    [
+      ...(selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS] ?? []).map((org) => org.districtId),
+      ...(selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES] ?? []).map((org) => org.districtId),
+      ...(selectedOrgs[FIRESTORE_COLLECTIONS.GROUPS] ?? []).map((org) => org.parentOrgId),
+    ].filter((districtId): districtId is string => !!districtId),
+  );
+
+const clearSelectedOrgs = () => {
+  selectedOrgs[FIRESTORE_COLLECTIONS.DISTRICTS] = [];
+  selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS] = [];
+  selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES] = [];
+  selectedOrgs[FIRESTORE_COLLECTIONS.GROUPS] = [];
+  selectedSchool.value = undefined;
+};
+
+const clearDistrictSelectedChildren = () => {
+  selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS] = [];
+  selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES] = [];
+  selectedOrgs[FIRESTORE_COLLECTIONS.GROUPS] = [];
+  selectedSchool.value = undefined;
+};
+
+const clearSchoolSelectedChildren = () => {
+  selectedOrgs[FIRESTORE_COLLECTIONS.CLASSES] = [];
+  selectedSchool.value = undefined;
+};
+
+const confirmParentSiteSelection = (nextDistricts: OrgItem[], previousDistricts: OrgItem[]) => {
+  if (isSelectionSyncing.value || !hasDistrictChildrenSelected()) return;
+
+  const newSelections = getNewSelections(nextDistricts, previousDistricts);
+  const districtChildrenIds = getDistrictSelectedChildrenIds();
+  const hasRelatedChild = newSelections.some((org) => districtChildrenIds.has(org.id));
+
+  if (!hasRelatedChild) return;
+
+  confirm.require({
+    header: 'Change to site selection?',
+    message: 'Selecting a site will clear its selected schools, classes, and cohorts. Do you want to continue?',
+    acceptLabel: 'Continue',
+    rejectLabel: 'Cancel',
+    rejectProps: {
+      label: 'Cancel',
+      severity: 'secondary',
+      outlined: true,
+    },
+    accept: () => {
+      syncSelection(() => {
+        clearDistrictSelectedChildren();
+        selectedOrgs[FIRESTORE_COLLECTIONS.DISTRICTS] = [...nextDistricts];
+      });
+    },
+    reject: () => {
+      syncSelection(() => {
+        selectedOrgs[FIRESTORE_COLLECTIONS.DISTRICTS] = [...previousDistricts];
+      });
+    },
+  });
+};
+
+const confirmParentSchoolSelection = (nextSchools: OrgItem[], previousSchools: OrgItem[]) => {
+  if (isSelectionSyncing.value || !hasSchoolChildrenSelected()) return;
+
+  const newSelections = getNewSelections(nextSchools, previousSchools);
+  const schoolChildrenIds = getSchoolSelectedChildrenIds();
+  const hasRelatedChild = newSelections.some((org) => schoolChildrenIds.has(org.id));
+
+  if (!hasRelatedChild) return;
+
+  confirm.require({
+    header: 'Change to school selection?',
+    message: 'Selecting a school will clear its selected classes. Do you want to continue?',
+    acceptLabel: 'Continue',
+    rejectLabel: 'Cancel',
+    rejectProps: {
+      label: 'Cancel',
+      severity: 'secondary',
+      outlined: true,
+    },
+    accept: () => {
+      syncSelection(() => {
+        clearSchoolSelectedChildren();
+        selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS] = [...nextSchools];
+      });
+    },
+    reject: () => {
+      syncSelection(() => {
+        selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS] = [...previousSchools];
+      });
+    },
+  });
+};
+
 const syncSelectedOrgsWithOrgData = (orgType: string, options: OrgItem[] | undefined) => {
   if (!options?.length) return;
 
@@ -252,16 +418,35 @@ watch(
   () => props.orgs,
   (newOrgs) => {
     if (newOrgs) {
-      if (newOrgs.districts) selectedOrgs.districts = [...(newOrgs.districts ?? [])];
-      if (newOrgs.schools) selectedOrgs.schools = [...(newOrgs.schools ?? [])];
-      if (newOrgs.classes) selectedOrgs.classes = [...(newOrgs.classes ?? [])];
-      if (newOrgs.groups) selectedOrgs.groups = [...(newOrgs.groups ?? [])];
+      syncSelection(() => {
+        if (newOrgs.districts) selectedOrgs.districts = [...(newOrgs.districts ?? [])];
+        if (newOrgs.schools) selectedOrgs.schools = [...(newOrgs.schools ?? [])];
+        if (newOrgs.classes) selectedOrgs.classes = [...(newOrgs.classes ?? [])];
+        if (newOrgs.groups) selectedOrgs.groups = [...(newOrgs.groups ?? [])];
+      });
+
       if (activeHeader.value && orgsData.value) {
         syncSelectedOrgsWithOrgData(activeHeader.value, orgsData.value);
       }
     }
   },
   { immediate: true, deep: true },
+);
+
+watch(
+  () => selectedOrgs[FIRESTORE_COLLECTIONS.DISTRICTS],
+  (nextDistricts = [], previousDistricts = []) => {
+    confirmParentSiteSelection(nextDistricts, previousDistricts);
+  },
+  { deep: true },
+);
+
+watch(
+  () => selectedOrgs[FIRESTORE_COLLECTIONS.SCHOOLS],
+  (nextSchools = [], previousSchools = []) => {
+    confirmParentSchoolSelection(nextSchools, previousSchools);
+  },
+  { deep: true },
 );
 
 watch(selectedOrgs, (newSelectedOrgs) => {


### PR DESCRIPTION
## Proposed changes

I added constraints to avoid selecting a child org if a parent is already selected. I also added a confirm popup for the backwards process, if the user tries to select a parent org when a child or is already selected.


https://github.com/user-attachments/assets/e42c4778-a6a1-4ebb-ae25-2142590d3033



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
