### PR TITLE
Fix small progress report bug and console typo

### DIFF
--- a/src/pages/ProgressReport.vue
+++ b/src/pages/ProgressReport.vue
@@ -56,7 +56,7 @@
             </div>
           </div>
 
-          <div v-if="!assignmentData?.length || !adminStats?.length" class="empty-user-list">
+          <div v-if="!assignmentData?.length || !adminStats?.assignment" class="empty-user-list">
             <div class="text-lg font-semibold text-gray-700">Could not find users for {{ orgData?.name }}.</div>
             <div class="mt-2 text-sm text-gray-500">
               <a href="/add-users">Add users</a> to <span class="font-bold">{{ orgData?.name }}</span> to see the

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -67,13 +67,13 @@ const getFallbackLocale = () => {
   const localeFromStorage = sessionStorage.getItem('levante') || '';
 
   if (localeFromStorage.includes('es')) {
-    console.log('Setting fallback local to es-CO');
+    console.log('Setting fallback locale to es-CO');
     return 'es-CO';
   } else if (localeFromStorage.includes('de')) {
-    console.log('Setting fallback local to de');
+    console.log('Setting fallback locale to de');
     return 'de';
   } else {
-    console.log('Setting fallback local to en-US');
+    console.log('Setting fallback locale to en-US');
     return 'en-US';
   }
 };


### PR DESCRIPTION
## Proposed changes

A check added in #778 to detect groups with no users when viewing the progress report had a small bug in it...`adminStats?.length` was false for all assignments because it's an object, not an array; so this was changed to `adminStats?.assignment`

Unrelated and technically unecessary, some debugging in i18n.ts was logging "local" instead of "locale" so just corrected that typo.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
