### PR TITLE
Removing "students" from UI and other small improvements to List Users

### DIFF
--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -114,6 +114,7 @@
           @row-unselect="onSelectionChange"
         >
           <PvColumn
+            v-if="props.allowRowSelection"
             selection-mode="multiple"
             header-style="background-color: var(--primary-color); border:none;"
             :reorderable-column="false"
@@ -454,6 +455,7 @@ const props = defineProps({
   showOptionsControl: { type: Boolean, default: true },
   showOptions: { type: Boolean, default: false },
   rowClass: { type: Function, default: null },
+  allowRowSelection: { type: Boolean, default: true },
 });
 
 /*
@@ -786,6 +788,12 @@ g {
   color: white;
   padding: 5px;
   margin-left: 10px;
+}
+
+.p-datatable .p-datatable-thead > tr > th {
+  min-height: 3rem !important;
+  padding-top: 0.75rem !important;
+  padding-bottom: 0.75rem !important;
 }
 
 .p-datatable .p-datatable-tbody > tr > td {


### PR DESCRIPTION
## Proposed changes

I found some remenants of student/parent in our UI on the List Users page (issue #712). This removes those and makes some minor improvements to the list users page:

- Remove student from the box on the upper right and replace it with Users, also adding a fold down that shows counts of child/caregiver/teacher users separately.
- Replaces student/parent in the UserType column with child/caregiver
- Removes the UID column - this often confuses researchers since they need to store local IDs and do not use our internal LEVANTE uids 
- Replaces the username column with User Login column displaying the email address - researchers are confused by the "bare" username as this does not occur in their registered user files
- Hides the column that allows user to select a row (it has no function here - at least not yet, it might in edit users) 
- Adds a minimum height to the header column, which was becoming too short in the absence of the radio buttons for selection 

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
