### PR TITLE
Fix small busy spinner in create-assignment loading overlay

### DIFF
--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="props.adminId && !isFormPopulated" class="levante-spinner-wrapper">
-    <LevanteSpinner />
+    <LevanteSpinner fullscreen />
   </div>
 
   <main v-else class="container main">


### PR DESCRIPTION
## Summary
- fix the create-assignment busy overlay to render `LevanteSpinner` in fullscreen mode
- keep change minimal and targeted to a single loading state

## Issue
In some dashboard states, the moving LEVANTE logo spinner appears unexpectedly small.

The root cause is prop mismatch at one loading call site:
- `CreateAssignment` uses a full-screen wrapper (`.levante-spinner-wrapper`) but renders `<LevanteSpinner />` without `fullscreen`.
- `LevanteSpinner` defaults to a smaller embedded size when `fullscreen` is not set.

This causes the logo to appear much smaller than other full-page busy screens.

## Fix
Update `CreateAssignment` loading branch from:
- `<LevanteSpinner />`

to:
- `<LevanteSpinner fullscreen />`

This aligns behavior with other app-wide busy overlays and ensures consistent spinner sizing.

## Why this is minimal
- one file changed: `src/pages/CreateAssignment.vue`
- one-line behavior fix
- no refactors, no style-system changes

## Test plan
- [x] verified loading branch now uses fullscreen spinner prop
- [x] no linter errors on changed file
- [ ] manually open create-assignment flow and confirm spinner size matches other fullscreen busy screens

Made with [Cursor](https://cursor.com)