### PR TITLE
Fix assignment date conversion for Firestore time format

### DIFF
--- a/src/helpers/query/administrations.js
+++ b/src/helpers/query/administrations.js
@@ -35,15 +35,37 @@ const mapAdministrations = async (data) => {
         groups: a.groups,
         families: a.families,
       };
+       // Convert dates to Date objects, handling both timestamp strings and Date objects
+      const convertToDate = (dateValue) => {
+        if (!dateValue) return null;
+        if (dateValue instanceof Date) return dateValue;
+
+
+         // If it's already a Date object, return it
+         if (dateValue instanceof Date) {
+          return isNaN(dateValue.getTime()) ? null : dateValue;
+        }
+        
+        // If it's a Firestore Timestamp object with toDate method
+        if (typeof dateValue === 'object' && typeof dateValue.toDate === 'function') {
+          return dateValue.toDate();
+        }
+        if (typeof dateValue === 'object' && typeof dateValue._seconds === 'number') {
+          const seconds = dateValue._seconds || 0;
+          const nanoseconds = dateValue._nanoseconds || 0;
+          return new Date(seconds * 1000 + nanoseconds / 1000000);
+        }
+        
+      };
 
       return {
         id: a.id,
         name: a.name,
         publicName: a.publicName,
         dates: {
-          start: a.dateOpened,
-          end: a.dateClosed,
-          created: a.dateCreated,
+          start: convertToDate(a.dateOpened),
+          end: convertToDate(a.dateClosed),
+          created: convertToDate(a.dateCreated),
         },
         assessments: a.assessments,
         assignedOrgs,


### PR DESCRIPTION
   ## Problem
After merging #805 to optimize administrations queries, all assignment date ranges were showing as "Invalid Date", causing all assignments to read as closed. The optimization changed how dates are returned from `getAdministrations()`. Dates are now Firestore Timestamp objects with `_seconds` and `_nanoseconds` properties instead of ISO strings. Updated `mapAdministrations` in `src/helpers/query/administrations.js` to properly convert Firestore Timestamp objects to JavaScript Date objects.
     
## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
