### PR TITLE
Adding CI/CD to deploy preview environment

### DIFF
--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -1,7 +1,7 @@
 name: Preview Deploy
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
     inputs:
       pr_branch:
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' || (github.event.action == 'labeled' && github.event.label.name == 'preview-assessment')
     env:
       VITE_LEVANTE: 'TRUE'
     steps:
@@ -67,6 +68,7 @@ jobs:
     name: Deploy Preview
     needs: test
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' || (github.event.action == 'labeled' && github.event.label.name == 'preview-assessment')
 
     steps:
       # For workflows triggered by pull requests
@@ -90,13 +92,27 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 
+      - name: Check for preview-assessment label
+        id: preview-label
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "has_preview_assessment=false" >> $GITHUB_OUTPUT
+          else
+            LABELS='${{ toJSON(github.event.pull_request.labels) }}'
+            echo "has_preview_assessment=$([[ "$LABELS" == *"preview-assessment"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build (ROAR)
         if: ${{ contains(github.repository, 'roar') }}
         run: npm ci && npm run build
 
-      - name: Build (LEVANTE)
-        if: ${{ contains(github.repository, 'levante') }}
+      - name: Build (LEVANTE - admin dev)
+        if: ${{ contains(github.repository, 'levante') && steps.preview-label.outputs.has_preview_assessment != 'true' }}
         run: npm ci && npm run build:dev
+
+      - name: Build (LEVANTE - assessment dev)
+        if: ${{ contains(github.repository, 'levante') && steps.preview-label.outputs.has_preview_assessment == 'true' }}
+        run: npm ci && npm run build:dev:assessment
 
       - name: Deploy to Firebase Hosting Channel
         id: firebase-deploy

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "survey:pdf": "node -e \"(async()=>{const {loadSurveyFromFile}=await import('./dist/helpers/surveyLoader.js'); const {generateSurveyPdfFromJson}=await import('./dist/helpers/surveyPdfGenerator.js'); const fp=process.env.SURVEY_JSON||'surveys/demo.json'; const survey=await loadSurveyFromFile(fp); await generateSurveyPdfFromJson(survey,{filename:(process.env.OUTPUT||'survey.pdf')});})().catch(e=>{console.error(e);process.exit(1);})\"",
     "build:dev": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=DEV && vite build",
+    "build:dev:assessment": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=DEV && export VITE_ADMIN_AS_APP=TRUE && vite build",
     "build:prod": "export VITE_LEVANTE=TRUE && vite build",
     "dev": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=DEV && export VITE_EMULATOR=TRUE && vite --force --host",
     "dev:db": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=DEV && vite --force --host",
+    "dev:preview:db": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=DEV && export VITE_ADMIN_AS_APP=TRUE && vite --force --host",
     "local:prod": "export VITE_LEVANTE=TRUE && export VITE_FIREBASE_PROJECT=PROD && vite --force --host",
     "dev:pc": "powershell -Command \"$env:VITE_LEVANTE='TRUE'; $env:VITE_FIREBASE_PROJECT='DEV'; vite --force --host\"",
     "deploy:dev": "npm run build:dev && npx firebase use levante-admin-dev && npx firebase deploy --only hosting --config levante-firebase.json",

--- a/src/config/firebaseLevante.js
+++ b/src/config/firebaseLevante.js
@@ -11,14 +11,17 @@ if (import.meta.env.VITE_FIREBASE_PROJECT === 'DEV') {
     appId: '1:46792247600:web:ea20e1fe94e0541dd5a0f5',
   };
 
-  adminConfig = {
-    apiKey: 'AIzaSyCOzRA9a2sDHtVlX7qnszxrgsRCBLyf5p0',
-    authDomain: 'hs-levante-admin-dev.firebaseapp.com',
-    projectId: 'hs-levante-admin-dev',
-    storageBucket: 'hs-levante-admin-dev.appspot.com',
-    messagingSenderId: '41590333418',
-    appId: '1:41590333418:web:3468a7caadab802d6e5c93',
-  };
+  adminConfig =
+    import.meta.env.VITE_ADMIN_AS_APP === 'TRUE'
+      ? appConfig
+      : {
+          apiKey: 'AIzaSyCOzRA9a2sDHtVlX7qnszxrgsRCBLyf5p0',
+          authDomain: 'hs-levante-admin-dev.firebaseapp.com',
+          projectId: 'hs-levante-admin-dev',
+          storageBucket: 'hs-levante-admin-dev.appspot.com',
+          messagingSenderId: '41590333418',
+          appId: '1:41590333418:web:3468a7caadab802d6e5c93',
+        };
 } else {
   // production
   appConfig = {


### PR DESCRIPTION
## Proposed changes

This adds a new CI/ CD pipeline that modifies the current preview deployment pipeline to run against the newly created online emulator (hs-levante-assessment-dev). With this PR:
1. Once you open a PR and add the label `preview-assessment` it will run the new pipeline
2. The preview environment will now point to `hs-levante-assessment-dev` and not `hs-levante-admin-dev`

This will be helpful for testing things that can break the current dev environment. This works in conjunction to:
https://github.com/levante-framework/levante-firebase-functions/pull/49

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
