### PR TITLE
Dev environment sign-in issue

### DIFF
--- a/src/pages/SignIn.vue
+++ b/src/pages/SignIn.vue
@@ -33,6 +33,7 @@
               label="Sign in with Google"
               class="inline-flex surface-0 p-2 border-black-alpha-10 text-center text-black justify-content-center hover:border-primary hover:surface-ground"
               style="border-radius: 3rem; height: 3rem; color: black !important"
+              :disabled="isAuthEmulator"
               @click="authWithGoogle"
             >
               <img src="../assets/provider-google-logo.svg" alt="The Google Logo" class="flex mr-2 w-1" />
@@ -40,6 +41,13 @@
             </PvButton>
           </div>
           <small class="mt-3 text-center text-color-secondary">*{{ $t('pageSignIn.adminInfoPrompt') }}</small>
+          <small v-if="isAuthEmulator" class="mt-2 text-center text-color-secondary">
+            Google SSO is disabled while running with Firebase emulators. Use <code>npm run dev:db</code> to sign in
+            with Google in development.
+          </small>
+          <small v-if="googleSignInError" class="mt-2 text-center p-error">
+            {{ googleSignInError }}
+          </small>
         </section>
         <!-- <section class="signin-option-container signin-option-providers">
           <div class="flex flex-row justify-content-center w-full">
@@ -134,6 +142,8 @@ const authStore = useAuthStore();
 const assignmentsStore = useAssignmentsStore();
 const router = useRouter();
 const adminSignIn = ref(false);
+const isAuthEmulator = import.meta.env.VITE_EMULATOR === 'TRUE';
+const googleSignInError = ref('');
 
 const { spinner, ssoProvider, routeToProfile, roarfirekit } = storeToRefs(authStore);
 const warningModalOpen = ref(false);
@@ -155,6 +165,12 @@ const toggleAdminSignIn = () => {
 };
 
 const authWithGoogle = () => {
+  googleSignInError.value = '';
+
+  if (isAuthEmulator) {
+    return;
+  }
+
   if (isMobileBrowser()) {
     authStore.signInWithGoogleRedirect();
   } else {
@@ -181,7 +197,12 @@ const authWithGoogle = () => {
           // User tried to register with an email that is already linked to a firebase account.
           openWarningModal();
           spinner.value = false;
+        } else if (errorCode === 'auth/unauthorized-domain') {
+          googleSignInError.value =
+            'This dev URL is not authorized for Google sign-in in Firebase. Add this host in Firebase Auth > Authorized domains, or use npm run dev:db from localhost.';
+          spinner.value = false;
         } else {
+          googleSignInError.value = 'Google sign-in failed. Please try again or sign in with email/password.';
           console.log('caught error', e);
           spinner.value = false;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

This PR addresses an issue where Google SSO was failing in the development environment when running `npm run dev`. The root cause was that `npm run dev` enables Firebase emulators, which conflicts with the real Google authentication setup.

To resolve this and provide clearer guidance, the following changes were made to `src/pages/SignIn.vue`:

*   The Google sign-in button is now disabled when `VITE_EMULATOR=TRUE`.
*   A clear message is displayed, instructing developers to use `npm run dev:db` for Google sign-in in development.
*   Improved error text for `auth/unauthorized-domain` to offer better guidance.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

*   For Google SSO to work locally, developers should use `npm run dev:db`.
*   If using a non-localhost development URL, ensure it is added to the Firebase Console's "Authentication" -> "Settings" -> "Authorized domains".

---
<p><a href="https://cursor.com/agents/bc-08c652bc-dcbd-4d10-a2da-3e71280c2b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c652bc-dcbd-4d10-a2da-3e71280c2b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->