### PR TITLE
Replaces hardcoded languageOptions with dynamic locale (i18n)

### DIFF
--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -44,11 +44,7 @@ export const languageOptions: Record<string, { translations: any; language: stri
     language: 'Español (Colombia)',
     code: 'col',
   },
-  'de-DE': {
-    translations: deTranslations,
-    language: 'Deutsch (Deutschland)',
-    code: 'de' 
-  },
+  // 'de-DE': { translations: deTranslations, language: 'Deutsch (Deutschland)', code: 'de' },
 };
 
 const browserLocale = window.navigator.language;
@@ -166,57 +162,49 @@ function addFlatKeys(messages: Record<string, any>): Record<string, any> {
 const baseMessages: Record<string, any> = {
   'en-US': addFlatKeys({ ...enUSTranslations, ...enUSIndividualScoreReport }),
   'es-CO': addFlatKeys({ ...esCOTranslations, ...esCOIndividualScoreReport }),
-  'de-DE': addFlatKeys(deTranslations),
+  'de': addFlatKeys(deTranslations),
   // Legacy fallbacks for backward compatibility
   // es: addFlatKeys({ ...esTranslations, ...esIndividualScoreReport }),
 };
 
-// Dynamically load any generated componentTranslations for new locales and merge
-// const modules = import.meta.glob('/src/translations/**/**-componentTranslations.json', { eager: true }) as Record<
-//   string,
-//   any
-// >;
-// for (const [filePath, mod] of Object.entries(modules)) {
-//   const match = filePath.match(/\/([a-z]{2}(?:-[a-z]{2})?)-componentTranslations\.json$/i);
-//   if (!match || !match[1]) continue;
-//   const rawLocale = match[1] as string; // e.g., en, es-co, fr-ca
-//   const locale = formatLocale(rawLocale);
-//   const content: Record<string, any> = ((mod as any)?.default ?? {}) as Record<string, any>;
+// Dynamic Language Fix (locale/translations)
+const modules = import.meta.glob(
+  '/src/translations/**/*-componentTranslations.json',
+  { eager: true },
+) as Record<string, any>;
 
-//   if (!baseMessages[locale]) baseMessages[locale] = {};
-//   deepMerge(baseMessages[locale] as Record<string, any>, content as Record<string, any>);
-  
-//   // Apply flat key transformation to dynamically loaded content
-//   baseMessages[locale] = addFlatKeys(baseMessages[locale]);
+for (const [filePath, mod] of Object.entries(modules)) {
+  const match = filePath.match(/([a-z]{2}(?:-[A-Z]{2})?)-componentTranslations\.json$/i);
+  if (!match || !match[1]) continue;
 
-//   // Auto-register new locales in languageOptions if missing
-//   if (!languageOptions[locale]) {
-//     let displayName = locale;
-//     try {
-//       const parts = locale.split('-');
-//       const langCode = (parts[0] || locale).toLowerCase();
-//       const regionCode = (parts[1] || '').toUpperCase();
+  const locale = formatLocale(match[1]);
+  const content = (mod?.default ?? {}) as Record<string, any>;
 
-//       // Language autonym (language name in its own language) with English fallback
-//       const langNames = new (window as any).Intl.DisplayNames([langCode, 'en'], { type: 'language' });
-//       // Region name in English for consistency
-//       const regionNames = new (window as any).Intl.DisplayNames(['en'], { type: 'region' });
+  if (!baseMessages[locale]) baseMessages[locale] = {};
+  deepMerge(baseMessages[locale] as Record<string, any>, content as Record<string, any>);
+  baseMessages[locale] = addFlatKeys(baseMessages[locale]);
 
-//       const langNameRaw = (langNames.of(langCode) as string | undefined) || langCode;
-//       const langName = /^[a-z]/.test(langNameRaw)
-//         ? langNameRaw.charAt(0).toLocaleUpperCase(langCode) + langNameRaw.slice(1)
-//         : langNameRaw;
-//       const regionName = regionCode ? (regionNames.of(regionCode) as string | undefined) : undefined;
-
-//       displayName = regionName ? `${langName} (${regionName})` : langName;
-//     } catch {
-//       // Fallback to locale string if Intl.DisplayNames is unavailable
-//     }
-
-//     const code = locale.includes('-') ? (locale.split('-')[1] || '').toLowerCase() : locale.toLowerCase();
-//     languageOptions[locale] = { translations: baseMessages[locale], language: displayName, code };
-//   }
-// }
+  if (!languageOptions[locale]) {
+    let displayName = locale;
+    try {
+      const parts = locale.split('-');
+      const langCode = (parts[0] || locale).toLowerCase();
+      const regionCode = (parts[1] || '').toUpperCase();
+      const langNames = new (window as any).Intl.DisplayNames([langCode, 'en'], { type: 'language' });
+      const regionNames = new (window as any).Intl.DisplayNames(['en'], { type: 'region' });
+      const langNameRaw = (langNames.of(langCode) as string | undefined) || langCode;
+      const langName = /^[a-z]/.test(langNameRaw)
+        ? langNameRaw.charAt(0).toLocaleUpperCase(langCode) + langNameRaw.slice(1)
+        : langNameRaw;
+      const regionName = regionCode ? (regionNames.of(regionCode) as string | undefined) : undefined;
+      displayName = regionName ? `${langName} (${regionName})` : langName;
+    } catch {
+      // fallback to locale string if Intl.DisplayNames unavailable
+    }
+    const code = locale.includes('-') ? (locale.split('-')[1] || '').toLowerCase() : locale.toLowerCase();
+    languageOptions[locale] = { translations: baseMessages[locale], language: displayName, code };
+  }
+}
 
 export const i18n = createI18n({
   locale: getLocale(browserLocale),


### PR DESCRIPTION
## Commit
- Removes hardcoded `languageOptions` limited to `en-US`, `es-CO`, and `de-DE`
- Uncomments and fixes `import.meta.glob` loader to auto-register all locales from CSV-generated `componentTranslations` JSON files
- Fixes `de-DE` key mismatch to `de`, matching the CSV/JSON file naming conventions
- Uses `Intl.DisplayNames` to generate locale display names automatically
- Partially addresses #829 and unblocks testing of #785

## Summary
The LEVANTE dashboard's `languageOptions` object in `src/translations/i18n.ts` was initially hardcoded to three locales (`en-US`, `es-CO`, and `de-DE`), despite 9 locale-specific `componentTranslations.json` files already existing via the CSV-to-JSON pipeline. This PR removes the hardcoded list and replaces it with a Vite `import.meta.glob` loader that auto-registers all available locales at build time. It requires no bucket infrastructure, no Crowdin token, and no dashboard release to add a new language.

## Problem
- Only 3 of 9 locales appeared in the dashboard user's "Language Selector" settings, despite translation files existing for all 9
- Assumption: a commented-out dynamic loader block was the intended solution, which appeared shelved pending Firebase Storage bucket work in #829 
- `de-DE` was registered as a locale key, but the file on disk is `de-componentTranslations.json`, which causes a mismatch between `baseMessages` and `languageOptions`

## Changes
- Removed hardcoded `languageOptions` entries for `de-DE`; kept `en-US` and `es-CO` as explicit base entries (these have additional imports no covered by the glob)
- Uncommented and updated the `import.meta.glob` block, fixing the regex to match both single-part (`de`) and two-part (`en-US`) locale codes
- Uses `Intl.DisplayNames` to generate locale display names automatically (e.g., "German," "French (Canada)")
- Fixed `baseMessages` key from `de-DE` to `de` to match the actual CSV-to-JSON file naming convention 

## Locale coverage
Before:
- `en-US`
- `es-CO`
- `de-DE`

After:
- `en-US`
- `es-CO`
- `de`
- `en-GH`
- `fr-CA`
- `nl`
- `de-CH`
- `es-AR`
- `es` (legacy fallback)

## Testing
Test Files: 43 (all 43 passed)
Tests: 236 (all 236 passed)

PASSED - VariantCard language variant testing:
- English (United States) (en-US)
- Spanish (Colombia) (es-CO)
- German (de)
- French (Canada) (fr-CA)
- Dutch (nl)
- English (Ghana) (en-GH)
- German (Switzerland) (de-CH)
- Spanish (Argentina) (es-AR)
- English (legacy) (en)
- Spanish (legacy) (es)

## Relationship to #829 and #785 
Issue #829 sets up the ability to pull `languageOptions` from Firebase Storage buckets (live/testing directories). This PR implements that same decoupling without the bucket dependency, using the translation files already on disk. It is intended to be a functional unblock that can be superseded by the full bucket-based implementation once #785 's activation workflow is in place. The 0% locales (see Testing) will register in the selector locally. A follow-up PR can enhance these incomplete locales behind an env guard (`VITE_FIREBASE_PROJECT=DEV`) once the testing/live Firebase Storage buckets are implemented.

## Files Changed
- `src/translations/i18n.ts`

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)