### PR TITLE
Fix confirm site change modal

### DIFF
--- a/src/composables/mutations/useSignOutMutation.ts
+++ b/src/composables/mutations/useSignOutMutation.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/vue';
 import { useAuthStore } from '@/store/auth';
 import { SIGN_OUT_MUTATION_KEY } from '@/constants/mutationKeys';
 import { APP_ROUTES } from '@/constants/routes';
+import { useLevanteStore } from '@/store/levante';
 import { useSurveyStore } from '@/store/survey';
 import { useAssignmentsStore } from '@/store/assignments';
 
@@ -16,6 +17,7 @@ import { useAssignmentsStore } from '@/store/assignments';
 const useSignOutMutation = (): UseMutationReturnType<void, Error, void, unknown> => {
   const assignmentsStore = useAssignmentsStore();
   const authStore = useAuthStore();
+  const levanteStore = useLevanteStore();
   const surveyStore = useSurveyStore();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -34,6 +36,7 @@ const useSignOutMutation = (): UseMutationReturnType<void, Error, void, unknown>
       assignmentsStore.$reset();
       authStore.$reset();
       assignmentsStore.$reset();
+      levanteStore.$reset();
       surveyStore.reset();
       sessionStorage.removeItem('authStore');
       sessionStorage.removeItem('assignmentsStore');

--- a/src/store/levante.ts
+++ b/src/store/levante.ts
@@ -14,6 +14,8 @@ export const useLevanteStore = defineStore(
     function $reset(): void {
       assignmentsSelectedFilter.value = null;
       assignmentsSelectedSorting.value = null;
+      hasUserConfirmed.value = false;
+      shouldUserConfirm.value = false;
     }
 
     function setAssignmentsSelectedFilter(filter: any): void {


### PR DESCRIPTION
## Proposed changes

This is a follow-on to PR #856 addressing issue #850. The first PR didn't fix the issue related to the "Change Site modal" because a reliable replication wasn't known then.

The issue is related to some state persisted in session storage not being reset on logout. This PR adds the missing state reset.

## Types of changes

What types of changes does this pull request introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

### Replication

- Log in
- Navigate to the Edit Assignment view
- Log out
- Log in again
- Attempt to change site
- Modal shows unexpectedly