### PR TITLE
remove backend normalization for link users

### DIFF
--- a/src/pages/users/LinkUsers.vue
+++ b/src/pages/users/LinkUsers.vue
@@ -120,7 +120,6 @@
 <script setup>
 import { ref, toRaw, watch, computed } from 'vue';
 import { csvFileToJson } from '@/helpers';
-import { normalizeUserTypeForBackend } from '@/helpers/userType';
 import { useToast } from 'primevue/usetoast';
 import { useAuthStore } from '@/store/auth';
 import LinkUsersInfo from '@/components/userInfo/LinkUsersInfo.vue';
@@ -466,8 +465,10 @@ const submitUsers = async () => {
       if (idField) normalizedUser.id = user[idField];
       if (userTypeField) {
         const userTypeValue = user[userTypeField];
+        // Link users: send CSV userType as-is (trimmed). Do not use normalizeUserTypeForBackend —
+        // the linkUsers Cloud Function expects child rows as "child", not "student".
         normalizedUser.userType =
-          typeof userTypeValue === 'string' ? normalizeUserTypeForBackend(userTypeValue.toLowerCase()) : userTypeValue;
+          typeof userTypeValue === 'string' ? userTypeValue.trim() : userTypeValue;
       }
       if (uidField) normalizedUser.uid = user[uidField];
 


### PR DESCRIPTION
## Proposed changes

The userType normalization "helper" itroduced in PR #858 (it was me) over-corrected by changing child to student before sending it to the backend; this backend function is already built to handle "child". Normalization removed.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
