### PR TITLE
Superadmin features in task picker

### DIFF
--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -36,7 +36,7 @@
             <i class="pi pi-times" />
           </PvButton>
         </div>
-        <div v-if="selectedLanguage">
+        <div v-if="selectedLanguage || isUserSuperAdmin()">
           <div v-if="searchTerm.length > 0">
             <div v-if="isSearching">
               <span>Searching...</span>
@@ -187,6 +187,7 @@ import { useToast } from 'primevue/usetoast';
 import { computed, nextTick, ref, watch } from 'vue';
 import { VueDraggableNext } from 'vue-draggable-next';
 import VariantCard from './VariantCard.vue';
+import { useAuthStore } from '@/store/auth';
 
 type VariantObject = InstanceType<typeof VariantCard>['$props']['variant'];
 
@@ -250,6 +251,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>();
 const toast = useToast();
+const authStore = useAuthStore();
+const { isUserSuperAdmin } = authStore;
 
 const languages = computed(() =>
   Object.entries(languageOptions).map(([key, options]) => ({

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -13,6 +13,7 @@
         <div class="flex align-items-center flex-row">
           <span class="font-bold">{{ variant.task.name }}</span>
           <PvButton
+            v-if="isUserSuperAdmin()"
             class="ml-2 p-0 surface-hover border-none border-circle hover:text-100 hover:bg-primary"
             @click="toggle($event)"
             ><i
@@ -276,6 +277,7 @@ import PvPopover from 'primevue/popover';
 import PvTag from 'primevue/tag';
 import EditVariantDialog from '@/components/EditVariantDialog.vue';
 import { formattedVariantName, getTooltip } from '@/helpers';
+import { useAuthStore } from '@/store/auth';
 
 interface Condition {
   field: string;
@@ -331,6 +333,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<Emits>();
+const authStore = useAuthStore();
+const { isUserSuperAdmin } = authStore;
 
 const backupImage = '/src/assets/roar-logo.png';
 const showContent = ref<boolean>(false);

--- a/src/components/tests/VariantCard.test.js
+++ b/src/components/tests/VariantCard.test.js
@@ -27,6 +27,12 @@ vi.mock('@/components/EditVariantDialog.vue', () => ({
   },
 }));
 
+vi.mock('@/store/auth', () => ({
+  useAuthStore: vi.fn(() => ({
+    isUserSuperAdmin: vi.fn(() => true),
+  })),
+}));
+
 const mockLanguages = [
   // Primary (full locales)
   {

--- a/src/pages/tests/CreateAssignment.test.js
+++ b/src/pages/tests/CreateAssignment.test.js
@@ -60,6 +60,7 @@ vi.mock('@/store/auth', () => ({
       },
       displayName: 'Test Display Name',
     }),
+    isUserSuperAdmin: vi.fn(() => true),
   })),
 }));
 


### PR DESCRIPTION
## Proposed changes

I updated the TaskPicker component to show all tasks by default when the logged-in user is a superadmin. On the other hand, if the user is not a superadmin, a language must be selected in order to show the tasks.

I also removed the variant info button for non-superadmin users.

On the following screen recording, you can see a super_admin on the left and a site_admin on the right.


https://github.com/user-attachments/assets/4129a9dd-5081-42d7-86b8-044f446f0033



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
