### PR TITLE
Pre-pend uploaded file name to registered users file

### DIFF
--- a/src/components/userInfo/AddUsersInfo.vue
+++ b/src/components/userInfo/AddUsersInfo.vue
@@ -189,7 +189,7 @@ const fileRequirementsTableData = [
 ];
 
 const downloadTemplate = () => {
-  downloadCsv(unparseCsvFile([], TEMPLATE_HEADERS), 'add_users_template.csv');
+  downloadCsv(unparseCsvFile([], TEMPLATE_HEADERS), 'users_template.csv');
 };
 </script>
 

--- a/src/components/userInfo/AddUsersInfo.vue
+++ b/src/components/userInfo/AddUsersInfo.vue
@@ -122,7 +122,7 @@ import PvAccordion from 'primevue/accordion';
 import PvAccordionPanel from 'primevue/accordionpanel';
 import PvAccordionHeader from 'primevue/accordionheader';
 import PvAccordionContent from 'primevue/accordioncontent';
-import { downloadCsv, unparseCsvFile } from '@/helpers/csv';
+import { deriveNextCsvFilename, downloadCsv, unparseCsvFile } from '@/helpers/csv';
 
 const TEMPLATE_HEADERS = ['id', 'userType', 'month', 'year', 'caregiverId', 'teacherId', 'school', 'class', 'cohort'];
 
@@ -189,7 +189,9 @@ const fileRequirementsTableData = [
 ];
 
 const downloadTemplate = () => {
-  downloadCsv(unparseCsvFile([], TEMPLATE_HEADERS), 'add-users.template.csv');
+  const csv = unparseCsvFile([], TEMPLATE_HEADERS);
+  const filename = deriveNextCsvFilename('add-users', { suffix: 'template' });
+  downloadCsv(csv, filename);
 };
 </script>
 

--- a/src/components/userInfo/AddUsersInfo.vue
+++ b/src/components/userInfo/AddUsersInfo.vue
@@ -189,7 +189,7 @@ const fileRequirementsTableData = [
 ];
 
 const downloadTemplate = () => {
-  downloadCsv(unparseCsvFile([], TEMPLATE_HEADERS), 'users_template.csv');
+  downloadCsv(unparseCsvFile([], TEMPLATE_HEADERS), 'add-users.template.csv');
 };
 </script>
 

--- a/src/helpers/csv.test.ts
+++ b/src/helpers/csv.test.ts
@@ -20,56 +20,56 @@ describe('deriveNextCsvFilename', () => {
   });
 
   it('strips the .csv extension before rebuilding the filename', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors' })).toBe('users_errors.csv');
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors' })).toBe('users.errors.csv');
   });
 
   it('strips the .CSV extension case-insensitively', () => {
-    expect(deriveNextCsvFilename('users.CSV', { suffix: 'errors' })).toBe('users_errors.csv');
+    expect(deriveNextCsvFilename('users.CSV', { suffix: 'errors' })).toBe('users.errors.csv');
   });
 
-  it('strips a trailing timestamp slug', () => {
-    expect(deriveNextCsvFilename(`users_${slug}.csv`, {})).toBe('users.csv');
+  it('strips a trailing dot-separated timestamp', () => {
+    expect(deriveNextCsvFilename(`users.${slug}.csv`, {})).toBe('users.csv');
   });
 
-  it('strips the _errors suffix', () => {
-    expect(deriveNextCsvFilename('users_errors.csv', {})).toBe('users.csv');
+  it('strips the .errors suffix', () => {
+    expect(deriveNextCsvFilename('users.errors.csv', {})).toBe('users.csv');
   });
 
-  it('strips the _registered suffix', () => {
-    expect(deriveNextCsvFilename('users_registered.csv', {})).toBe('users.csv');
+  it('strips the .registered suffix', () => {
+    expect(deriveNextCsvFilename('users.registered.csv', {})).toBe('users.csv');
   });
 
-  it('strips the _template suffix', () => {
-    expect(deriveNextCsvFilename('users_template.csv', {})).toBe('users.csv');
+  it('strips the .template suffix', () => {
+    expect(deriveNextCsvFilename('users.template.csv', {})).toBe('users.csv');
   });
 
   it('strips a timestamp that follows a suffix', () => {
-    expect(deriveNextCsvFilename(`users_errors_${slug}.csv`, {})).toBe('users.csv');
+    expect(deriveNextCsvFilename(`users.errors_${slug}.csv`, {})).toBe('users.csv');
   });
 
   it('appends the suffix when options.suffix is provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'registered' })).toBe('users_registered.csv');
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'registered' })).toBe('users.registered.csv');
   });
 
   it('appends a timestamp when options.now is provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { now: date })).toBe(`users_${slug}.csv`);
+    expect(deriveNextCsvFilename('users.csv', { now: date })).toBe(`users.${slug}.csv`);
   });
 
   it('appends suffix before timestamp when both options are provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors', now: date })).toBe(`users_errors_${slug}.csv`);
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors', now: date })).toBe(`users.errors_${slug}.csv`);
   });
 
   it('replaces an old timestamp with a new one', () => {
     const oldSlug = '20230101-0900';
-    expect(deriveNextCsvFilename(`users_${oldSlug}.csv`, { now: date })).toBe(`users_${slug}.csv`);
+    expect(deriveNextCsvFilename(`users.${oldSlug}.csv`, { now: date })).toBe(`users.${slug}.csv`);
   });
 
   it('replaces an old suffix with a new one', () => {
-    expect(deriveNextCsvFilename('users_errors.csv', { suffix: 'registered' })).toBe('users_registered.csv');
+    expect(deriveNextCsvFilename('users.errors.csv', { suffix: 'registered' })).toBe('users.registered.csv');
   });
 
-  it('falls back to the basename when stripping produces an empty name', () => {
-    expect(deriveNextCsvFilename('_errors.csv', {})).toBe('_errors.csv');
+  it('does not strip underscore-separated suffixes', () => {
+    expect(deriveNextCsvFilename('users_errors.csv', {})).toBe('users_errors.csv');
   });
 });
 

--- a/src/helpers/csv.test.ts
+++ b/src/helpers/csv.test.ts
@@ -12,64 +12,47 @@ const makeFile = (content: string[][]) =>
   new File([content.map((row) => row.join(',')).join('\n')], 'test.csv', { type: 'text/csv' });
 
 describe('deriveNextCsvFilename', () => {
-  const date = new Date(2024, 10, 28, 14, 35);
-  const slug = '20241128-1435';
+  const suffix = 'registered';
+  const timestamp = new Date(2024, 10, 28, 14, 35);
+  const timestampStr = '20241128-1435';
 
-  it('returns the filename with .csv when no options are given', () => {
-    expect(deriveNextCsvFilename('users.csv', {})).toBe('users.csv');
+  it('adds .csv extension when filename does not have it', () => {
+    expect(deriveNextCsvFilename('foo')).toBe('foo.csv');
+    expect(deriveNextCsvFilename('foo.txt')).toBe('foo.txt.csv');
   });
 
-  it('strips the .csv extension before rebuilding the filename', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors' })).toBe('users.errors.csv');
+  it('replaces .csv extension case-insensitively', () => {
+    expect(deriveNextCsvFilename('foo.Csv')).toBe('foo.csv');
+    expect(deriveNextCsvFilename('foo.CSV', { suffix })).toBe(`foo__${suffix}.csv`);
+    expect(deriveNextCsvFilename('foo.cSV', { suffix, timestamp })).toBe(`foo__${suffix}-${timestampStr}.csv`);
   });
 
-  it('strips the .CSV extension case-insensitively', () => {
-    expect(deriveNextCsvFilename('users.CSV', { suffix: 'errors' })).toBe('users.errors.csv');
+  it('returns the filename with no metadata when no options are given', () => {
+    expect(deriveNextCsvFilename('foo.csv')).toBe('foo.csv');
   });
 
-  it('strips a trailing dot-separated timestamp', () => {
-    expect(deriveNextCsvFilename(`users.${slug}.csv`, {})).toBe('users.csv');
+  it('adds metadata when options are provided', () => {
+    expect(deriveNextCsvFilename('foo.csv', { suffix })).toBe(`foo__${suffix}.csv`);
+    expect(deriveNextCsvFilename('foo.csv', { timestamp })).toBe(`foo__${timestampStr}.csv`);
+    expect(deriveNextCsvFilename('foo.csv', { suffix, timestamp })).toBe(`foo__${suffix}-${timestampStr}.csv`);
   });
 
-  it('strips the .errors suffix', () => {
-    expect(deriveNextCsvFilename('users.errors.csv', {})).toBe('users.csv');
+  it('strips previous metadata', () => {
+    expect(deriveNextCsvFilename(`foo__${suffix}.csv`)).toBe('foo.csv');
+    expect(deriveNextCsvFilename(`foo__${timestampStr}.csv`)).toBe('foo.csv');
+    expect(deriveNextCsvFilename(`foo__${suffix}-${timestampStr}.csv`)).toBe('foo.csv');
   });
 
-  it('strips the .registered suffix', () => {
-    expect(deriveNextCsvFilename('users.registered.csv', {})).toBe('users.csv');
+  it('replaces old metadata with new metadata', () => {
+    expect(deriveNextCsvFilename(`foo__errors-20260508-1407.csv`, { suffix })).toBe(`foo__${suffix}.csv`);
+    expect(deriveNextCsvFilename(`foo__errors-20260508-1407.csv`, { timestamp })).toBe(`foo__${timestampStr}.csv`);
+    expect(deriveNextCsvFilename(`foo__errors-20260508-1407.csv`, { suffix, timestamp })).toBe(
+      `foo__${suffix}-${timestampStr}.csv`,
+    );
   });
 
-  it('strips the .template suffix', () => {
-    expect(deriveNextCsvFilename('users.template.csv', {})).toBe('users.csv');
-  });
-
-  it('strips a timestamp that follows a suffix', () => {
-    expect(deriveNextCsvFilename(`users.errors_${slug}.csv`, {})).toBe('users.csv');
-  });
-
-  it('appends the suffix when options.suffix is provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'registered' })).toBe('users.registered.csv');
-  });
-
-  it('appends a timestamp when options.now is provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { now: date })).toBe(`users.${slug}.csv`);
-  });
-
-  it('appends suffix before timestamp when both options are provided', () => {
-    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors', now: date })).toBe(`users.errors_${slug}.csv`);
-  });
-
-  it('replaces an old timestamp with a new one', () => {
-    const oldSlug = '20230101-0900';
-    expect(deriveNextCsvFilename(`users.${oldSlug}.csv`, { now: date })).toBe(`users.${slug}.csv`);
-  });
-
-  it('replaces an old suffix with a new one', () => {
-    expect(deriveNextCsvFilename('users.errors.csv', { suffix: 'registered' })).toBe('users.registered.csv');
-  });
-
-  it('does not strip underscore-separated suffixes', () => {
-    expect(deriveNextCsvFilename('users_errors.csv', {})).toBe('users_errors.csv');
+  it('only strips metadata and extension', () => {
+    expect(deriveNextCsvFilename('foo_bar_baz__registered-20260508-1407.csv')).toBe('foo_bar_baz.csv');
   });
 });
 

--- a/src/helpers/csv.test.ts
+++ b/src/helpers/csv.test.ts
@@ -1,8 +1,77 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { downloadCsv, generateColumns, parseCsvFile, unparseCsvFile } from './csv';
+import {
+  deriveNextCsvFilename,
+  downloadCsv,
+  formatTimestamp,
+  generateColumns,
+  parseCsvFile,
+  unparseCsvFile,
+} from './csv';
 
 const makeFile = (content: string[][]) =>
   new File([content.map((row) => row.join(',')).join('\n')], 'test.csv', { type: 'text/csv' });
+
+describe('deriveNextCsvFilename', () => {
+  const date = new Date(2024, 10, 28, 14, 35);
+  const slug = '20241128-1435';
+
+  it('returns the filename with .csv when no options are given', () => {
+    expect(deriveNextCsvFilename('users.csv', {})).toBe('users.csv');
+  });
+
+  it('strips the .csv extension before rebuilding the filename', () => {
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors' })).toBe('users_errors.csv');
+  });
+
+  it('strips the .CSV extension case-insensitively', () => {
+    expect(deriveNextCsvFilename('users.CSV', { suffix: 'errors' })).toBe('users_errors.csv');
+  });
+
+  it('strips a trailing timestamp slug', () => {
+    expect(deriveNextCsvFilename(`users_${slug}.csv`, {})).toBe('users.csv');
+  });
+
+  it('strips the _errors suffix', () => {
+    expect(deriveNextCsvFilename('users_errors.csv', {})).toBe('users.csv');
+  });
+
+  it('strips the _registered suffix', () => {
+    expect(deriveNextCsvFilename('users_registered.csv', {})).toBe('users.csv');
+  });
+
+  it('strips the _template suffix', () => {
+    expect(deriveNextCsvFilename('users_template.csv', {})).toBe('users.csv');
+  });
+
+  it('strips a timestamp that follows a suffix', () => {
+    expect(deriveNextCsvFilename(`users_errors_${slug}.csv`, {})).toBe('users.csv');
+  });
+
+  it('appends the suffix when options.suffix is provided', () => {
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'registered' })).toBe('users_registered.csv');
+  });
+
+  it('appends a timestamp when options.now is provided', () => {
+    expect(deriveNextCsvFilename('users.csv', { now: date })).toBe(`users_${slug}.csv`);
+  });
+
+  it('appends suffix before timestamp when both options are provided', () => {
+    expect(deriveNextCsvFilename('users.csv', { suffix: 'errors', now: date })).toBe(`users_errors_${slug}.csv`);
+  });
+
+  it('replaces an old timestamp with a new one', () => {
+    const oldSlug = '20230101-0900';
+    expect(deriveNextCsvFilename(`users_${oldSlug}.csv`, { now: date })).toBe(`users_${slug}.csv`);
+  });
+
+  it('replaces an old suffix with a new one', () => {
+    expect(deriveNextCsvFilename('users_errors.csv', { suffix: 'registered' })).toBe('users_registered.csv');
+  });
+
+  it('falls back to the basename when stripping produces an empty name', () => {
+    expect(deriveNextCsvFilename('_errors.csv', {})).toBe('_errors.csv');
+  });
+});
 
 describe('downloadCsv', () => {
   let createObjectURL: ReturnType<typeof vi.fn>;
@@ -77,6 +146,28 @@ describe('downloadCsv', () => {
 
     const [blob] = createObjectURL.mock.calls[0] as unknown as [Blob];
     expect(await blob.text()).toBe('id,name\n1,Alice');
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('formats a date as YYYYMMDD-HHMM', () => {
+    expect(formatTimestamp(new Date(2024, 10, 28, 14, 35))).toBe('20241128-1435');
+  });
+
+  it('pads a single-digit month with a leading zero', () => {
+    expect(formatTimestamp(new Date(2024, 0, 28, 14, 35))).toBe('20240128-1435');
+  });
+
+  it('pads a single-digit day with a leading zero', () => {
+    expect(formatTimestamp(new Date(2024, 10, 5, 14, 35))).toBe('20241105-1435');
+  });
+
+  it('pads single-digit hours with a leading zero', () => {
+    expect(formatTimestamp(new Date(2024, 10, 28, 9, 35))).toBe('20241128-0935');
+  });
+
+  it('pads single-digit minutes with a leading zero', () => {
+    expect(formatTimestamp(new Date(2024, 10, 28, 14, 7))).toBe('20241128-1407');
   });
 });
 

--- a/src/helpers/csv.ts
+++ b/src/helpers/csv.ts
@@ -36,33 +36,30 @@ export const csvFileToJson = async (file: File): Promise<any[]> => {
 /**
  * Derive the next CSV filename from a base filename and options
  * @param filename The base filename
- * @param options.now The date to add to the filename
  * @param options.suffix The suffix to add to the filename
+ * @param options.timestamp The date to add to the filename
  * @returns The next CSV filename
  */
 export function deriveNextCsvFilename(
   filename: string,
   options: {
-    now?: Date;
     suffix?: string;
-  },
+    timestamp?: Date;
+  } = {},
 ): string {
-  const next = [];
-
   // Strip metadata and extension
-  const basename = filename.replace(/(\.[^.]+)?\.csv$/i, '');
-  next.push(basename);
+  let next = filename.replace(/(__.+)?\.csv$/i, '');
 
   // Add metadata
   const metadata: string[] = [];
   if (options.suffix) metadata.push(options.suffix);
-  if (options.now) metadata.push(formatTimestamp(options.now));
-  if (metadata.length) next.push(metadata.join('_'));
+  if (options.timestamp) metadata.push(formatTimestamp(options.timestamp));
+  if (metadata.length) next += `__${metadata.join('-')}`;
 
   // Add extension
-  next.push('csv');
+  next += '.csv';
 
-  return next.join('.');
+  return next;
 }
 
 /**

--- a/src/helpers/csv.ts
+++ b/src/helpers/csv.ts
@@ -44,26 +44,25 @@ export function deriveNextCsvFilename(
   filename: string,
   options: {
     now?: Date;
-    suffix?: 'errors' | 'registered' | 'template';
+    suffix?: string;
   },
 ): string {
-  const basename = filename.replace(/\.csv$/i, '');
+  const next = [];
 
-  // Strip timestamp
-  let name = basename.replace(/_\d{8}-\d{4}$/, '');
-  // Strip suffix
-  name = name.replace(/_errors$/, '');
-  name = name.replace(/_registered$/, '');
-  name = name.replace(/_template$/, '');
+  // Strip metadata and extension
+  const basename = filename.replace(/(\.[^.]+)?\.csv$/i, '');
+  next.push(basename);
 
-  // Add suffix
-  if (options.suffix && options.suffix.length) name += `_${options.suffix}`;
-  // Add timestamp
-  if (options.now) name += `_${formatTimestamp(options.now)}`;
+  // Add metadata
+  const metadata: string[] = [];
+  if (options.suffix) metadata.push(options.suffix);
+  if (options.now) metadata.push(formatTimestamp(options.now));
+  if (metadata.length) next.push(metadata.join('_'));
 
-  if (name.length === 0) name = basename;
+  // Add extension
+  next.push('csv');
 
-  return `${name}.csv`;
+  return next.join('.');
 }
 
 /**

--- a/src/helpers/csv.ts
+++ b/src/helpers/csv.ts
@@ -34,6 +34,39 @@ export const csvFileToJson = async (file: File): Promise<any[]> => {
 };
 
 /**
+ * Derive the next CSV filename from a base filename and options
+ * @param filename The base filename
+ * @param options.now The date to add to the filename
+ * @param options.suffix The suffix to add to the filename
+ * @returns The next CSV filename
+ */
+export function deriveNextCsvFilename(
+  filename: string,
+  options: {
+    now?: Date;
+    suffix?: 'errors' | 'registered' | 'template';
+  },
+): string {
+  const basename = filename.replace(/\.csv$/i, '');
+
+  // Strip timestamp
+  let name = basename.replace(/_\d{8}-\d{4}$/, '');
+  // Strip suffix
+  name = name.replace(/_errors$/, '');
+  name = name.replace(/_registered$/, '');
+  name = name.replace(/_template$/, '');
+
+  // Add suffix
+  if (options.suffix && options.suffix.length) name += `_${options.suffix}`;
+  // Add timestamp
+  if (options.now) name += `_${formatTimestamp(options.now)}`;
+
+  if (name.length === 0) name = basename;
+
+  return `${name}.csv`;
+}
+
+/**
  * Trigger a browser download of a CSV string.
  * @param csv The CSV string to download
  * @param filename The filename to use for the downloaded file
@@ -50,6 +83,21 @@ export const downloadCsv = (csv: string, filename: string) => {
   document.body.removeChild(link);
   URL.revokeObjectURL(csvUrl);
 };
+
+/**
+ * Format a date for CSV filenames
+ * @param now The date to format
+ * @returns A YYYYMMDD-HHMM string
+ */
+export function formatTimestamp(now: Date): string {
+  const day = now.getDate().toString().padStart(2, '0');
+  const month = (now.getMonth() + 1).toString().padStart(2, '0');
+  const year = now.getFullYear();
+  const hours = now.getHours().toString().padStart(2, '0');
+  const minutes = now.getMinutes().toString().padStart(2, '0');
+
+  return `${year}${month}${day}-${hours}${minutes}`;
+}
 
 /**
  * Generate CSV columns from a JSON object.

--- a/src/pages/users/AddUsers.test.ts
+++ b/src/pages/users/AddUsers.test.ts
@@ -641,7 +641,7 @@ describe('AddUsers Page', () => {
       expect(removeChildMock).toHaveBeenCalledOnce();
       const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
       expect(link.getAttribute('href')).toBe('mock-blob-url');
-      expect(link.getAttribute('download')).toMatch(/^test_errors_\d{8}-\d{4}\.csv$/);
+      expect(link.getAttribute('download')).toMatch(/^test\.errors_\d{8}-\d{4}\.csv$/);
 
       // Parse the blob back as CSV so we can assert the 'errors' column is
       // populated per row, rather than just probing for substrings.
@@ -1325,7 +1325,7 @@ describe('AddUsers Page', () => {
         expect(removeChildMock).toHaveBeenCalledOnce();
         const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
         expect(link.getAttribute('href')).toBe('mock-blob-url');
-        expect(link.getAttribute('download')).toMatch(/^test_registered_\d{8}-\d{4}\.csv$/);
+        expect(link.getAttribute('download')).toMatch(/^test\.registered_\d{8}-\d{4}\.csv$/);
 
         const csvText = await blob.text();
         const lines = csvText.split('\n');

--- a/src/pages/users/AddUsers.test.ts
+++ b/src/pages/users/AddUsers.test.ts
@@ -641,7 +641,7 @@ describe('AddUsers Page', () => {
       expect(removeChildMock).toHaveBeenCalledOnce();
       const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
       expect(link.getAttribute('href')).toBe('mock-blob-url');
-      expect(link.getAttribute('download')).toBe('add-users-errors.csv');
+      expect(link.getAttribute('download')).toMatch(/^test_errors_\d{8}-\d{4}\.csv$/);
 
       // Parse the blob back as CSV so we can assert the 'errors' column is
       // populated per row, rather than just probing for substrings.
@@ -1307,6 +1307,7 @@ describe('AddUsers Page', () => {
             uid: 'uid-2',
           },
         ];
+        vm.uploadedFile = createMockFile('', 'test.csv');
 
         vm.downloadRegisteredUsers();
 
@@ -1324,7 +1325,7 @@ describe('AddUsers Page', () => {
         expect(removeChildMock).toHaveBeenCalledOnce();
         const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
         expect(link.getAttribute('href')).toBe('mock-blob-url');
-        expect(link.getAttribute('download')).toBe('registered-users.csv');
+        expect(link.getAttribute('download')).toMatch(/^test_registered_\d{8}-\d{4}\.csv$/);
 
         const csvText = await blob.text();
         const lines = csvText.split('\n');

--- a/src/pages/users/AddUsers.test.ts
+++ b/src/pages/users/AddUsers.test.ts
@@ -641,7 +641,7 @@ describe('AddUsers Page', () => {
       expect(removeChildMock).toHaveBeenCalledOnce();
       const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
       expect(link.getAttribute('href')).toBe('mock-blob-url');
-      expect(link.getAttribute('download')).toMatch(/^test\.errors_\d{8}-\d{4}\.csv$/);
+      expect(link.getAttribute('download')).toMatch(/^test__errors-\d{8}-\d{4}\.csv$/);
 
       // Parse the blob back as CSV so we can assert the 'errors' column is
       // populated per row, rather than just probing for substrings.
@@ -1325,7 +1325,7 @@ describe('AddUsers Page', () => {
         expect(removeChildMock).toHaveBeenCalledOnce();
         const link = appendChildMock.mock.calls[0]?.[0] as HTMLAnchorElement;
         expect(link.getAttribute('href')).toBe('mock-blob-url');
-        expect(link.getAttribute('download')).toMatch(/^test\.registered_\d{8}-\d{4}\.csv$/);
+        expect(link.getAttribute('download')).toMatch(/^test__registered-\d{8}-\d{4}\.csv$/);
 
         const csvText = await blob.text();
         const lines = csvText.split('\n');

--- a/src/pages/users/AddUsers.vue
+++ b/src/pages/users/AddUsers.vue
@@ -306,9 +306,9 @@ const downloadErrors = () => {
   });
 
   // Download the Error CSV file
-  const csvString = unparseCsvFile(mapped);
-  const csvFilename = deriveNextCsvFilename(uploadedFile.value.name, { now: new Date(), suffix: 'errors' });
-  downloadCsv(csvString, csvFilename);
+  const csv = unparseCsvFile(mapped);
+  const filename = deriveNextCsvFilename(uploadedFile.value.name, { suffix: 'errors', timestamp: new Date() });
+  downloadCsv(csv, filename);
 };
 
 const submitUsers = async () => {
@@ -589,9 +589,9 @@ const downloadRegisteredUsers = () => {
   if (!registeredUsers.value || registeredUsers.value.length === 0 || !uploadedFile.value) return;
 
   // Download the Registered CSV file
-  const csvString = unparseCsvFile(toRaw(registeredUsers.value), USER_CSV_HEADERS);
-  const csvFilename = deriveNextCsvFilename(uploadedFile.value.name, { now: new Date(), suffix: 'registered' });
-  downloadCsv(csvString, csvFilename);
+  const csv = unparseCsvFile(toRaw(registeredUsers.value), USER_CSV_HEADERS);
+  const filename = deriveNextCsvFilename(uploadedFile.value.name, { suffix: 'registered', timestamp: new Date() });
+  downloadCsv(csv, filename);
 };
 </script>
 

--- a/src/pages/users/AddUsers.vue
+++ b/src/pages/users/AddUsers.vue
@@ -113,7 +113,7 @@ import AddUsersInfo from '@/components/userInfo/AddUsersInfo.vue';
 import { NORMALIZED_USER_CSV_HEADERS, USER_CSV_HEADERS } from '@/constants/csv';
 import { CreateUsersPayload, usersRepository } from '@/firebase/repositories/UsersRepository';
 import { normalizeToLowercase } from '@/helpers';
-import { downloadCsv, parseCsvFile, unparseCsvFile } from '@/helpers/csv';
+import { deriveNextCsvFilename, downloadCsv, parseCsvFile, unparseCsvFile } from '@/helpers/csv';
 import { fetchOrgByName } from '@/helpers/query/orgs';
 import { normalizeUserTypeForBackend } from '@/helpers/userType';
 import { logger } from '@/logger';
@@ -287,7 +287,7 @@ const onFileUpload = async (event: FileUploadUploaderEvent) => {
 };
 
 const downloadErrors = () => {
-  if (!parsedData.value || !validationErrors.value) return;
+  if (!parsedData.value || !validationErrors.value || !uploadedFile.value) return;
 
   // Map errors column to the rows
   const data = toRaw(parsedData.value);
@@ -305,10 +305,10 @@ const downloadErrors = () => {
     };
   });
 
+  // Download the Error CSV file
   const csvString = unparseCsvFile(mapped);
-
-  // Initiate download
-  downloadCsv(csvString, 'add-users-errors.csv');
+  const csvFilename = deriveNextCsvFilename(uploadedFile.value.name, { now: new Date(), suffix: 'errors' });
+  downloadCsv(csvString, csvFilename);
 };
 
 const submitUsers = async () => {
@@ -586,13 +586,12 @@ const runWithConcurrency = async <T, R>(
 };
 
 const downloadRegisteredUsers = () => {
-  if (!registeredUsers.value || registeredUsers.value.length === 0) return;
+  if (!registeredUsers.value || registeredUsers.value.length === 0 || !uploadedFile.value) return;
 
-  // Convert objects to CSV string
+  // Download the Registered CSV file
   const csvString = unparseCsvFile(toRaw(registeredUsers.value), USER_CSV_HEADERS);
-
-  // Initiate download
-  downloadCsv(csvString, 'registered-users.csv');
+  const csvFilename = deriveNextCsvFilename(uploadedFile.value.name, { now: new Date(), suffix: 'registered' });
+  downloadCsv(csvString, csvFilename);
 };
 </script>
 


### PR DESCRIPTION
## Proposed changes

I updated the registered users file to include the uploaded file name as well as a timestamp. Some examples follow:

**Uploaded file -> Registered file**
`test-file` -> `test-file_20260423_1035_registered.csv`
`test.file` -> `test.file_20260423_1035_registered.csv`
`another.test.file` -> `another.test.file_20260423_1035_registered.csv`


https://github.com/user-attachments/assets/575571a4-0dc9-4e73-ae47-0f49c109972f



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
