### PR TITLE
Fix: edit assignment data corruption

### DIFF
--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -1023,19 +1023,19 @@ watch(
     const mo = minimalOrgsFromDoc(admin);
     if (mo.districts?.length) {
       const next = existingDistrictsData.value;
-      if (next !== undefined) state.districts = next;
+      if (next) state.districts = next;
     }
     if (mo.schools?.length) {
       const next = existingSchoolsData.value;
-      if (next !== undefined) state.schools = next;
+      if (next) state.schools = next;
     }
     if (mo.classes?.length) {
       const next = existingClassesData.value;
-      if (next !== undefined) state.classes = next;
+      if (next) state.classes = next;
     }
     if (mo.groups?.length) {
       const next = existingGroupData.value;
-      if (next !== undefined) state.groups = next;
+      if (next) state.groups = next;
     }
   },
 );

--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -309,21 +309,6 @@ const {
   gcTime: 0,
 });
 
-const editAssignmentBlockingLoader = computed(() => {
-  if (!props.adminId) return false;
-  if (!initialized.value) return true;
-  if (errorExistingData?.value != null) return false;
-
-  const admin = existingData?.value;
-  if (!admin) {
-    return isLoadingExistingData.value || !isAdministrationFetched.value;
-  }
-
-  if (!administrationMatchesRoute(admin, props.adminId)) return true;
-
-  return !isFormPopulated.value || !editTasksHydrated.value;
-});
-
 watch(
   [existingData, isLoadingExistingData, errorExistingData],
   ([newExistingData, newIsLoadingExistingData, newErrorExistingData]) => {
@@ -353,29 +338,56 @@ const existingAdminMinimalOrgs = computed(() => minimalOrgsFromDoc(existingData?
 // Fetch the districts assigned to the administration.
 const districtIds = computed(() => existingAdminMinimalOrgs.value?.districts ?? []);
 
-const { data: existingDistrictsData } = useDistrictsQuery(districtIds, {
+const { data: existingDistrictsData, isFetched: isDistrictsFetched } = useDistrictsQuery(districtIds, {
   enabled: initialized,
 });
 
 // Fetch the schools assigned to the administration.
 const schoolIds = computed(() => existingAdminMinimalOrgs.value?.schools ?? []);
 
-const { data: existingSchoolsData } = useSchoolsQuery(schoolIds, {
+const { data: existingSchoolsData, isFetched: isSchoolsFetched } = useSchoolsQuery(schoolIds, {
   enabled: initialized,
 });
 
 // Fetch the classes assigned to the administration.
 const classIds = computed(() => existingAdminMinimalOrgs.value?.classes ?? []);
 
-const { data: existingClassesData } = useClassesQuery(classIds, {
+const { data: existingClassesData, isFetched: isClassesFetched } = useClassesQuery(classIds, {
   enabled: initialized,
 });
 
 // Fetch the groups assigned to the administration.
 const groupIds = computed(() => existingAdminMinimalOrgs.value?.groups ?? []);
 
-const { data: existingGroupData } = useGroupsQuery(groupIds, {
+const { data: existingGroupData, isFetched: isGroupsFetched } = useGroupsQuery(groupIds, {
   enabled: initialized,
+});
+
+const editOrgsHydrated = computed(() => {
+  const mo = existingAdminMinimalOrgs.value ?? {};
+  console.log('mo', mo);
+  const ready = (ids, isFetchedRef) => !ids?.length || isFetchedRef.value;
+  return (
+    ready(mo.districts, isDistrictsFetched) &&
+    ready(mo.schools, isSchoolsFetched) &&
+    ready(mo.classes, isClassesFetched) &&
+    ready(mo.groups, isGroupsFetched)
+  );
+});
+
+const editAssignmentBlockingLoader = computed(() => {
+  if (!props.adminId) return false;
+  if (!initialized.value) return true;
+  if (errorExistingData?.value != null) return false;
+
+  const admin = existingData?.value;
+  if (!admin) {
+    return isLoadingExistingData.value || !isAdministrationFetched.value;
+  }
+
+  if (!administrationMatchesRoute(admin, props.adminId)) return true;
+
+  return !isFormPopulated.value || !editTasksHydrated.value || !editOrgsHydrated.value;
 });
 
 // +------------------------------------------------------------------------------------------------------------------+

--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -461,14 +461,15 @@ const handleVariantsChanged = (newVariants) => {
 };
 
 const handleConsentSelected = (newConsentAssent) => {
-  if (newConsentAssent !== 'No Consent') {
+  const isNoConsent =
+    typeof newConsentAssent === 'string' && newConsentAssent.toLowerCase() === 'no consent';
+  if (!isNoConsent) {
     noConsent.value = '';
     state.consent = newConsentAssent.consent;
     state.assent = newConsentAssent.assent;
     state.amount = newConsentAssent.amount;
     state.expectedTime = newConsentAssent.expectedTime;
   } else {
-    // Set to "No Consent"
     noConsent.value = newConsentAssent;
     state.consent = newConsentAssent;
     state.assent = newConsentAssent;
@@ -952,7 +953,7 @@ function applyAdministrationMetadataToForm(adminInfo) {
   state.assent = adminInfo?.legal?.assent ?? null;
   isTestData.value = adminInfo.testData;
 
-  if (state.consent === 'No Consent') {
+  if (state.consent?.toLowerCase() === 'no consent') {
     noConsent.value = state.consent;
   }
 }

--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -365,7 +365,6 @@ const { data: existingGroupData, isFetched: isGroupsFetched } = useGroupsQuery(g
 
 const editOrgsHydrated = computed(() => {
   const mo = existingAdminMinimalOrgs.value ?? {};
-  console.log('mo', mo);
   const ready = (ids, isFetchedRef) => !ids?.length || isFetchedRef.value;
   return (
     ready(mo.districts, isDistrictsFetched) &&
@@ -982,17 +981,12 @@ watch(
 );
 
 watch(
-  [
-    () => props.adminId,
-    existingData,
-    existingDistrictsData,
-    existingSchoolsData,
-    existingClassesData,
-    existingGroupData,
-  ],
-  ([adminId, admin]) => {
+  [() => props.adminId, existingData, editOrgsHydrated],
+  ([adminId, admin, orgsHydrated]) => {
+    if (isFormPopulated.value) return;
     if (!adminId || !admin) return;
     if (!administrationMatchesRoute(admin, adminId)) return;
+    if (!orgsHydrated) return;
     applyAdministrationMetadataToForm(admin);
     isFormPopulated.value = true;
   },
@@ -1017,39 +1011,6 @@ watch(
     editTasksHydrated.value = true;
   },
   { immediate: true },
-);
-
-watch(
-  [
-    existingDistrictsData,
-    existingSchoolsData,
-    existingClassesData,
-    existingGroupData,
-    existingData,
-    isFormPopulated,
-  ],
-  () => {
-    if (!props.adminId || !isFormPopulated.value) return;
-    const admin = existingData?.value;
-    if (!admin) return;
-    const mo = minimalOrgsFromDoc(admin);
-    if (mo.districts?.length) {
-      const next = existingDistrictsData.value;
-      if (next) state.districts = next;
-    }
-    if (mo.schools?.length) {
-      const next = existingSchoolsData.value;
-      if (next) state.schools = next;
-    }
-    if (mo.classes?.length) {
-      const next = existingClassesData.value;
-      if (next) state.classes = next;
-    }
-    if (mo.groups?.length) {
-      const next = existingGroupData.value;
-      if (next) state.groups = next;
-    }
-  },
 );
 </script>
 

--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="props.adminId && !isFormPopulated" class="levante-spinner-wrapper">
+  <div v-if="editAssignmentBlockingLoader" class="levante-spinner-wrapper">
     <LevanteSpinner fullscreen />
   </div>
 
@@ -191,13 +191,11 @@ import PvRadioButton from 'primevue/radiobutton';
 import _filter from 'lodash/filter';
 import _isEmpty from 'lodash/isEmpty';
 import _toPairs from 'lodash/toPairs';
-import _uniqBy from 'lodash/uniqBy';
 import _forEach from 'lodash/forEach';
 import _find from 'lodash/find';
 import _isEqual from 'lodash/isEqual';
 import _union from 'lodash/union';
 import _groupBy from 'lodash/groupBy';
-import _values from 'lodash/values';
 import { useVuelidate } from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import { useAuthStore } from '@/store/auth';
@@ -224,6 +222,7 @@ import { logger } from '@/logger';
 
 const initialized = ref(false);
 const isFormPopulated = ref(false);
+const editTasksHydrated = ref(false);
 const router = useRouter();
 const toast = useToast();
 const queryClient = useQueryClient();
@@ -270,7 +269,26 @@ const findVariantWithParams = (variants, params) => {
   });
 };
 
-const { data: allVariants } = useTaskVariantsQuery(true, {
+function resolveVariantForAssessment(assessment, allVariantInfo) {
+  const taskId = assessment?.taskId;
+  const tid = String(taskId ?? '').toLowerCase();
+  const forTask = _filter(allVariantInfo, (variant) =>
+    String(variant.task?.id ?? '').toLowerCase() === tid,
+  );
+
+  let found = findVariantWithParams(forTask, assessment.params ?? {});
+
+  const variantId = assessment.variantId;
+  if (!found && variantId) {
+    found =
+      _find(forTask, (v) => v.id === variantId) ??
+      _find(allVariantInfo, (v) => v.id === variantId);
+  }
+
+  return found;
+}
+
+const { data: allVariants, isFetched: isVariantsFetched } = useTaskVariantsQuery(true, {
   enabled: initialized,
 });
 
@@ -278,21 +296,39 @@ const { data: allVariants } = useTaskVariantsQuery(true, {
 // | Fetch pre-existing administration data when editing an administration
 // +------------------------------------------------------------------------------------------------------------------+
 // Fetch the data of the currently being edited administration, incl. its assigned assessments.
+const administrationIdsForEdit = computed(() => (props.adminId ? [props.adminId] : []));
 const fetchAdminitrations = computed(() => initialized.value && !!props.adminId);
 const {
   data: existingData,
   isLoading: isLoadingExistingData,
   error: errorExistingData,
-} = useAdministrationsQuery([props.adminId], {
+  isFetched: isAdministrationFetched,
+} = useAdministrationsQuery(administrationIdsForEdit, {
   enabled: fetchAdminitrations,
   select: (data) => data[0],
   staleTime: 0,
   gcTime: 0,
 });
 
+const editAssignmentBlockingLoader = computed(() => {
+  if (!props.adminId) return false;
+  if (!initialized.value) return true;
+  if (errorExistingData?.value != null) return false;
+
+  const admin = existingData?.value;
+  if (!admin) {
+    return isLoadingExistingData.value || !isAdministrationFetched.value;
+  }
+
+  if (!administrationMatchesRoute(admin, props.adminId)) return true;
+
+  return !isFormPopulated.value || !editTasksHydrated.value;
+});
+
 watch(
   [existingData, isLoadingExistingData, errorExistingData],
   ([newExistingData, newIsLoadingExistingData, newErrorExistingData]) => {
+    if (!props.adminId) return;
     if (!newIsLoadingExistingData && !newExistingData) {
       logger.error('Failed to fetch administration by id', {
         assignmentId: props.adminId,
@@ -302,7 +338,7 @@ watch(
       toast.add({
         severity: TOAST_SEVERITIES.ERROR,
         summary: 'Failed to fetch assignment',
-        detail: "We could not fetch this assignment's data. Please try again later",
+        detail: 'We could not fetch this assignment\'s data. Please try again later',
         life: TOAST_DEFAULT_LIFE_DURATION,
       });
 
@@ -313,29 +349,31 @@ watch(
 
 const existingAssessments = computed(() => existingData?.value?.assessments ?? []);
 
+const existingAdminMinimalOrgs = computed(() => minimalOrgsFromDoc(existingData?.value));
+
 // Fetch the districts assigned to the administration.
-const districtIds = computed(() => existingData?.value?.minimalOrgs?.districts ?? []);
+const districtIds = computed(() => existingAdminMinimalOrgs.value?.districts ?? []);
 
 const { data: existingDistrictsData } = useDistrictsQuery(districtIds, {
   enabled: initialized,
 });
 
 // Fetch the schools assigned to the administration.
-const schoolIds = computed(() => existingData.value?.minimalOrgs?.schools ?? []);
+const schoolIds = computed(() => existingAdminMinimalOrgs.value?.schools ?? []);
 
 const { data: existingSchoolsData } = useSchoolsQuery(schoolIds, {
   enabled: initialized,
 });
 
 // Fetch the classes assigned to the administration.
-const classIds = computed(() => existingData.value?.minimalOrgs?.classes ?? []);
+const classIds = computed(() => existingAdminMinimalOrgs.value?.classes ?? []);
 
 const { data: existingClassesData } = useClassesQuery(classIds, {
   enabled: initialized,
 });
 
 // Fetch the groups assigned to the administration.
-const groupIds = computed(() => existingData.value?.minimalOrgs?.groups ?? []);
+const groupIds = computed(() => existingAdminMinimalOrgs.value?.groups ?? []);
 
 const { data: existingGroupData } = useGroupsQuery(groupIds, {
   enabled: initialized,
@@ -414,7 +452,6 @@ const selection = (selected) => {
 // +------------------------------------------------------------------------------------------------------------------+
 const variants = ref([]);
 const preSelectedVariants = ref([]);
-const nonUniqueTasks = ref('');
 
 const variantsByTaskId = computed(() => {
   return _groupBy(allVariants.value, 'task.id');
@@ -490,25 +527,24 @@ const hasAssignmentChanges = () => {
   // If no original data exists (new assignment), there are always changes
   if (!original) return true;
 
-  // Compare name
-  if (current.administrationName !== original.name) {
+  const originalName = original.name ?? original.publicName ?? '';
+  if (current.administrationName !== originalName) {
     return true;
   }
 
-  // Compare dates - normalize to compare only date part (ignore time)
   const normalizeDate = (date) => {
     if (!date) return null;
     const d = new Date(date);
     return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
   };
 
-  const originalStartDate = normalizeDate(original.dateOpened);
+  const originalStartDate = normalizeDate(original.dateOpened ?? original.dateOpen);
   const currentStartDate = normalizeDate(current.dateStarted);
   if (originalStartDate !== currentStartDate) {
     return true;
   }
 
-  const originalEndDate = normalizeDate(original.dateClosed);
+  const originalEndDate = normalizeDate(original.dateClosed ?? original.dateClose);
   const currentEndDate = normalizeDate(current.dateClosed);
   if (originalEndDate !== currentEndDate) {
     return true;
@@ -531,7 +567,7 @@ const hasAssignmentChanges = () => {
       .sort();
   };
 
-  const originalOrgs = original.minimalOrgs ?? {};
+  const originalOrgs = minimalOrgsFromDoc(original);
   const currentDistricts = getOrgIds(current.districts);
   const currentSchools = getOrgIds(current.schools);
   const currentClasses = getOrgIds(current.classes);
@@ -600,12 +636,9 @@ const hasAssignmentChanges = () => {
 };
 
 const submit = async () => {
-  console.log('Submit function called');
   submitted.value = true;
 
-  // Set publicName automatically based on administrationName
   state.administrationPublicName = state.administrationName;
-  console.log('Set administrationPublicName:', state.administrationPublicName);
 
   // First check dates
   if (!state.dateStarted || !state.dateClosed) {
@@ -637,11 +670,8 @@ const submit = async () => {
     groups: toRaw(state.groups).map((org) => org.id),
   };
 
-  console.log('Checking required orgs...', orgs);
   const orgsValid = checkForRequiredOrgs(orgs);
-  console.log('Orgs valid result:', orgsValid);
   if (!orgsValid) {
-    console.log('Org check failed, showing toast.');
     toast.add({
       severity: TOAST_SEVERITIES.ERROR,
       summary: 'Missing Selection',
@@ -867,41 +897,148 @@ watch(
 );
 
 watch(hasUserConfirmed, (userConfirmed) => {
-  if (userConfirmed) resetUserProgress();
+  if (userConfirmed && !props.adminId) resetUserProgress();
 });
 
-watch([existingData, allVariants], ([adminInfo, allVariantInfo]) => {
-  if (adminInfo && !_isEmpty(allVariantInfo)) {
-    state.administrationName = adminInfo.name;
-    state.administrationPublicName = adminInfo.name;
-    state.dateStarted = new Date(adminInfo.dateOpened);
-    state.dateClosed = new Date(adminInfo.dateClosed);
-    state.districts = adminInfo.districts;
-    state.schools = adminInfo.schools;
-    state.classes = adminInfo.classes;
-    state.groups = adminInfo.groups;
-    state.sequential = adminInfo.sequential;
+function normalizeOrgListForState(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => (typeof item === 'string' ? { id: item } : item));
+}
+
+function minimalOrgsFromDoc(admin) {
+  if (!admin) return {};
+  return admin.minimalOrgs ?? admin.assignedOrgs ?? {};
+}
+
+function administrationMatchesRoute(admin, routeAdminId) {
+  if (!admin || !routeAdminId) return false;
+  const docId = admin.id;
+  if (docId == null) return true;
+  return String(docId) === String(routeAdminId);
+}
+
+function applyAdministrationMetadataToForm(adminInfo) {
+  const displayName = adminInfo.name ?? adminInfo.publicName ?? '';
+  state.administrationName = displayName;
+  state.administrationPublicName = adminInfo.publicName ?? adminInfo.name ?? displayName;
+
+  const opened = adminInfo.dateOpened ?? adminInfo.dateOpen;
+  const closed = adminInfo.dateClosed ?? adminInfo.dateClose;
+  state.dateStarted = opened ? new Date(opened) : null;
+  state.dateClosed = closed ? new Date(closed) : null;
+
+  const mo = minimalOrgsFromDoc(adminInfo);
+  const expectsFetchedOrgs =
+    (mo.districts?.length ?? 0) +
+      (mo.schools?.length ?? 0) +
+      (mo.classes?.length ?? 0) +
+      (mo.groups?.length ?? 0) >
+    0;
+
+  if (expectsFetchedOrgs) {
+    state.districts = existingDistrictsData.value ?? [];
+    state.schools = existingSchoolsData.value ?? [];
+    state.classes = existingClassesData.value ?? [];
+    state.groups = existingGroupData.value ?? [];
+  } else {
+    state.districts = normalizeOrgListForState(adminInfo.districts);
+    state.schools = normalizeOrgListForState(adminInfo.schools);
+    state.classes = normalizeOrgListForState(adminInfo.classes);
+    state.groups = normalizeOrgListForState(adminInfo.groups);
+  }
+
+  state.sequential = adminInfo.sequential;
+  state.legal = adminInfo.legal;
+  state.consent = adminInfo?.legal?.consent ?? null;
+  state.assent = adminInfo?.legal?.assent ?? null;
+  isTestData.value = adminInfo.testData;
+
+  if (state.consent === 'No Consent') {
+    noConsent.value = state.consent;
+  }
+}
+
+watch(
+  () => props.adminId,
+  (nextId, prevId) => {
+    if (nextId === prevId) return;
+    preSelectedVariants.value = [];
+    variants.value = [];
+    isFormPopulated.value = false;
+    editTasksHydrated.value = false;
+  },
+);
+
+watch(
+  [
+    () => props.adminId,
+    existingData,
+    existingDistrictsData,
+    existingSchoolsData,
+    existingClassesData,
+    existingGroupData,
+  ],
+  ([adminId, admin]) => {
+    if (!adminId || !admin) return;
+    if (!administrationMatchesRoute(admin, adminId)) return;
+    applyAdministrationMetadataToForm(admin);
+    isFormPopulated.value = true;
+  },
+  { immediate: true },
+);
+
+watch(
+  [existingData, allVariants, isVariantsFetched],
+  ([adminInfo, allVariantInfo, variantsFetched]) => {
+    if (!props.adminId) return;
+    if (!adminInfo || !administrationMatchesRoute(adminInfo, props.adminId)) return;
+    if (!variantsFetched || !Array.isArray(allVariantInfo)) return;
+
+    preSelectedVariants.value = [];
     _forEach(adminInfo.assessments, (assessment) => {
-      const assessmentParams = assessment.params;
-      const taskId = assessment.taskId;
-      const allVariantsForThisTask = _filter(allVariantInfo, (variant) => variant.task.id === taskId);
-      const found = findVariantWithParams(allVariantsForThisTask, assessmentParams);
+      const found = resolveVariantForAssessment(assessment, allVariantInfo);
       if (found) {
         preSelectedVariants.value = _union(preSelectedVariants.value, [found]);
       }
     });
-    state.legal = adminInfo.legal;
-    state.consent = adminInfo?.legal?.consent ?? null;
-    state.assent = adminInfo?.legal?.assent ?? null;
-    isTestData.value = adminInfo.testData;
+    variants.value = preSelectedVariants.value.slice();
+    editTasksHydrated.value = true;
+  },
+  { immediate: true },
+);
 
-    if (state.consent === 'No Consent') {
-      noConsent.value = state.consent;
+watch(
+  [
+    existingDistrictsData,
+    existingSchoolsData,
+    existingClassesData,
+    existingGroupData,
+    existingData,
+    isFormPopulated,
+  ],
+  () => {
+    if (!props.adminId || !isFormPopulated.value) return;
+    const admin = existingData?.value;
+    if (!admin) return;
+    const mo = minimalOrgsFromDoc(admin);
+    if (mo.districts?.length) {
+      const next = existingDistrictsData.value;
+      if (next !== undefined) state.districts = next;
     }
-
-    isFormPopulated.value = true;
-  }
-});
+    if (mo.schools?.length) {
+      const next = existingSchoolsData.value;
+      if (next !== undefined) state.schools = next;
+    }
+    if (mo.classes?.length) {
+      const next = existingClassesData.value;
+      if (next !== undefined) state.classes = next;
+    }
+    if (mo.groups?.length) {
+      const next = existingGroupData.value;
+      if (next !== undefined) state.groups = next;
+    }
+  },
+);
 </script>
 
 <style lang="scss" scoped>

--- a/src/pages/CreateAssignment.vue
+++ b/src/pages/CreateAssignment.vue
@@ -270,10 +270,9 @@ const findVariantWithParams = (variants, params) => {
 };
 
 function resolveVariantForAssessment(assessment, allVariantInfo) {
-  const taskId = assessment?.taskId;
-  const tid = String(taskId ?? '').toLowerCase();
+  const taskId = String(assessment?.taskId ?? '').toLowerCase();
   const forTask = _filter(allVariantInfo, (variant) =>
-    String(variant.task?.id ?? '').toLowerCase() === tid,
+    String(variant.task?.id ?? '').toLowerCase() === taskId,
   );
 
   let found = findVariantWithParams(forTask, assessment.params ?? {});


### PR DESCRIPTION
## Proposed changes

[Bug] Groups evaluating to null on frontend during edit assignment [#899](https://github.com/levante-framework/levante-dashboard/issues/899)

Issues found during the fix:
1 | Blank form after leaving and returning to edit until a hard refresh
2 | Loader hiding too soon when cached data appeared before the form was filled in
3 | Selected tasks missing because the UI appeared before task hydration finished
4 | Variant list briefly treated as empty (non-array cleared selections)
5 | Loader out of sync with real state (metadata loaded but tasks not yet)
6 | Tasks missing on Edit due to strict param-only matching so added variant-id fallback and case-insensitive task ids
7 | Parent “variants” state briefly out of sync with the task picker

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

