### PR TITLE
Fix total progress 'denominator' 

### DIFF
--- a/src/pages/ProgressReportFeature.vue
+++ b/src/pages/ProgressReportFeature.vue
@@ -385,10 +385,12 @@ const taskChartStats = computed(() => {
 const totalChartStats = computed(() => {
   const users = progressUsers.value;
   if (!users.length) return null;
+
+  const assignedTotal = users.length;
   const completed = users.filter((u) => u.status === 'completed').length;
-  const started = users.filter((u) => u.status === 'started').length;
-  const notStarted = users.filter((u) => u.status === 'notStarted').length;
-  return statsFromExclusiveCounts(notStarted, started, completed);
+  const startedOnly = users.filter((u) => u.status === 'started').length;
+  const notStarted = Math.max(0, assignedTotal - completed - startedOnly);
+  return statsFromExclusiveCounts(notStarted, startedOnly, completed);
 });
 
 const totalAssignedCount = computed(() => progressUsers.value.length);

--- a/src/types/administrationOrgProgress.ts
+++ b/src/types/administrationOrgProgress.ts
@@ -1,6 +1,6 @@
 export type OrgCollectionKey = 'districts' | 'schools' | 'classes' | 'groups';
 
-export type AssignmentRollupStatus = 'notStarted' | 'started' | 'completed';
+export type AssignmentRollupStatus = 'notStarted' | 'started' | 'completed' | 'notAssigned';
 
 export interface TaskProgressBreakdown {
   taskId: string;


### PR DESCRIPTION
## Proposed changes
The progress report was sometimes showing an incorrect total width for the total progress bar due to some users being counted as "not assigned" - this is correct for per task counts but doesn't work for the total. 
<img width="1370" height="650" alt="Untitled 14(1)" src="https://github.com/user-attachments/assets/4fea4bcc-a06b-4d3e-a87e-4365f8f7758c" />


Minor change to align progress bar width with the value in "Assiged to X users" that displays to the left.

<img width="2888" height="1426" alt="Untitled 14" src="https://github.com/user-attachments/assets/f7b3e720-e11a-4e07-a303-29c44c347d96" />

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

