### PR TITLE
Modify task picker language filter to rely on variant.params.language instead of name

### DIFF
--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -277,7 +277,7 @@ const rebuildAvailableSearchResults = (): void => {
   );
 };
 
-// TODO: Remove the following function after fixing core-tasks
+// @TODO: Remove the following function after normalizing the variant docs
 const formatVariantLanguage = (variantLanguage: string): string => {
   if (!variantLanguage) return '';
 

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -277,13 +277,15 @@ const rebuildAvailableSearchResults = (): void => {
   );
 };
 
-const getVariantLanguage = (variantName: string): string => {
-  if (!variantName) return '';
-  // TODO: Remove the following line after fixing core-tasks
-  if (variantName === 'es') return 'es-CO';
-  if (variantName.length <= 5) return variantName;
-  const parts = variantName.split(' ');
-  return parts[0] ?? '';
+// TODO: Remove the following function after fixing core-tasks
+const formatVariantLanguage = (variantLanguage: string): string => {
+  if (!variantLanguage) return '';
+
+  if (variantLanguage === 'en') return 'en-us';
+  if (variantLanguage === 'es') return 'es-co';
+  if (variantLanguage === 'de') return 'de-de';
+
+  return variantLanguage?.toLowerCase();
 };
 
 const variantsByLanguage = (variants: VariantObject[] = []): VariantObject[] => {
@@ -292,13 +294,13 @@ const variantsByLanguage = (variants: VariantObject[] = []): VariantObject[] => 
   const selectedLang = selectedLanguage.value.value.toLowerCase();
 
   return variants.filter((variant) => {
-    const variantName = variant.variant?.name?.toLowerCase();
-    if (!variantName) return false;
-    if (variantName === 'all languages') return true;
+    const variantLanguage = variant.variant?.params?.language?.toLowerCase();
+    if (!variantLanguage) return false;
+    if (variantLanguage === 'all languages') return true;
 
-    const variantLanguage = getVariantLanguage(variantName);
-    const exactLangMatch = variantLanguage === selectedLang;
-    const langPrefixMatch = selectedLang.includes(variantLanguage);
+    const formattedVariantLanguage = formatVariantLanguage(variantLanguage);
+    const exactLangMatch = formattedVariantLanguage === selectedLang;
+    const langPrefixMatch = selectedLang.includes(formattedVariantLanguage);
 
     return exactLangMatch || langPrefixMatch;
   });


### PR DESCRIPTION
## Proposed changes

Updated the language filter in the task picker to use the `variant.params.language` instead of `variant.name` prop.


https://github.com/user-attachments/assets/13d9880a-69d4-4fdb-9e52-1a5387525fb1



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
