### PR TITLE
Allow super admins to create sites from All Sites

### DIFF
--- a/src/components/modals/AddGroupModal.vue
+++ b/src/components/modals/AddGroupModal.vue
@@ -151,11 +151,19 @@ const queryClient = useQueryClient();
 const isDistrictTabActive = computed(() => props?.activeTabOrg?.singular === SINGULAR_ORG_TYPES.DISTRICTS);
 const isUserSuperAdmin = computed(() => userRole.value === ROLES.SUPER_ADMIN);
 const isSubmitBtnDisabled = ref(false);
+const isSubmitting = ref(false);
+const orgName = ref('');
+const orgType = ref<OrgType | undefined>();
 
 watch(
-  () => authStore.currentSite,
-  (newCurrentSite) => {
-    if (!newCurrentSite || newCurrentSite.toLowerCase() === 'any') {
+  () => ({
+    currentSite: authStore.currentSite,
+    isCreatingSite: orgType.value?.singular === SINGULAR_ORG_TYPES.DISTRICTS,
+    isUserSuperAdmin: isUserSuperAdmin.value,
+  }),
+  ({ currentSite, isCreatingSite, isUserSuperAdmin }) => {
+    const canCreateSiteFromAllSites = isCreatingSite && isUserSuperAdmin;
+    if ((!currentSite || currentSite.toLowerCase() === 'any') && !canCreateSiteFromAllSites) {
       isSubmitBtnDisabled.value = true;
     } else {
       isSubmitBtnDisabled.value = false;
@@ -164,9 +172,6 @@ watch(
   { immediate: true },
 );
 
-const isSubmitting = ref(false);
-const orgName = ref('');
-const orgType = ref<OrgType | undefined>();
 const orgTypeLabel = computed(() => {
   if (!orgType.value || (isDistrictTabActive.value && !isUserSuperAdmin.value)) return 'Group';
   return _capitalize(orgType.value.label);


### PR DESCRIPTION
## Summary
- Allows super admins to submit the Add Group modal when creating a Site from the All Sites scope.
- Reorders modal refs so the current-site watcher can safely inspect the selected org type immediately.

## Test plan
- ReadLints on `src/components/modals/AddGroupModal.vue` passed.
- Validated via the emulator UI-seeding work that Site creation is no longer blocked for super admins.