### PR TITLE
Remove assessmentUid references

### DIFF
--- a/src/pages/ViewAssignments.test.js
+++ b/src/pages/ViewAssignments.test.js
@@ -159,7 +159,6 @@ describe('ViewAssignments', () => {
               classes: [],
             },
             roarUid: 'zbTRSOS70cNGWyu2Ecc4T2aOU2y2',
-            assessmentUid: 'mlrlu8rqPYh3IeXKHT83UpVMtzE2',
             admin: true,
             adminUid: 'zbTRSOS70cNGWyu2Ecc4T2aOU2y2',
           },


### PR DESCRIPTION
## Proposed changes

Removed the only reference to `assessmentUid` in the dashboard.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
