### PR TITLE
Change filter for ROAR tasks/task picker filter language display

### DIFF
--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -227,6 +227,12 @@ interface TaskSection {
 
 const getTaskId = (task: VariantObject['task']): string => (task as unknown as { id: string }).id;
 
+const LANGUAGE_PREFIX_MATCH_TASK_IDS = new Set(['swr', 'sre', 'pa']);
+
+function getLanguagePrefix(locale: string): string {
+  return locale.split('-')[0] ?? locale.slice(0, 2);
+}
+
 const groupedTasks: Record<string, string[]> = {
   Introduction: ['Instructions'],
   'Language and Literacy': [
@@ -256,7 +262,7 @@ const { isUserSuperAdmin } = authStore;
 
 const languages = computed(() =>
   Object.entries(languageOptions).map(([key, options]) => ({
-    name: options.languageMenu,
+    name: options.languageTaskPicker,
     value: key,
   })),
 );
@@ -299,6 +305,12 @@ const variantsByLanguage = (variants: VariantObject[] = []): VariantObject[] => 
     if (variantLanguage === 'all languages') return true;
 
     const formattedVariantLanguage = formatVariantLanguage(variantLanguage);
+    const taskId = getTaskId(variant.task).toLowerCase();
+
+    if (LANGUAGE_PREFIX_MATCH_TASK_IDS.has(taskId)) {
+      return getLanguagePrefix(selectedLang) === getLanguagePrefix(formattedVariantLanguage);
+    }
+
     const exactLangMatch = formattedVariantLanguage === selectedLang;
     const langPrefixMatch = selectedLang.includes(formattedVariantLanguage);
 


### PR DESCRIPTION
## Proposed changes

This PR addresses issue #938 
- Filtering by any es- locale now shows Spanish ROAR tasks
- Task picker language filter displays English terms for languages

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
