### PR TITLE
Add privacy policy page and sign-in footer links

### DIFF
--- a/.cursor/rules/context-mode.mdc
+++ b/.cursor/rules/context-mode.mdc
@@ -1,0 +1,52 @@
+---
+description: context-mode routing rules for context window protection
+alwaysApply: true
+---
+
+# context-mode
+
+Raw tool output floods your context window. Use context-mode MCP tools to keep raw data in the sandbox.
+
+## Think in Code — MANDATORY
+
+When you need to analyze, count, filter, compare, search, parse, transform, or process data: **write code** that does the work via `ctx_execute(language, code)` and `console.log()` only the answer. Do NOT read raw data into context to process mentally. Your role is to PROGRAM the analysis, not to COMPUTE it. Write robust, pure JavaScript — no npm dependencies, only Node.js built-ins (`fs`, `path`, `child_process`). Always use `try/catch`, handle `null`/`undefined`, and ensure compatibility with both Node.js and Bun. One script replaces ten tool calls and saves 100x context.
+
+## Tool Selection Hierarchy
+
+1. **GATHER**: `ctx_batch_execute(commands, queries)` — Primary tool for research. Runs all commands, auto-indexes, and searches. ONE call replaces many individual steps.
+2. **FOLLOW-UP**: `ctx_search(queries: ["q1", "q2", ...])` — Use for all follow-up questions. ONE call, many queries.
+3. **PROCESSING**: `ctx_execute(language, code)` or `ctx_execute_file(path, language, code)` — Use for API calls, log analysis, and data processing.
+4. **WEB**: `ctx_fetch_and_index(url)` then `ctx_search(queries)` — Fetch, index, then query. Never dump raw HTML.
+5. **INDEX**: `ctx_index(content, source)` — Store content in FTS5 knowledge base for later search.
+
+## Forbidden Actions
+
+- DO NOT use Bash for commands producing >20 lines of output — use `ctx_execute` or `ctx_batch_execute`.
+- DO NOT use Read for analysis — use `ctx_execute_file`. Read IS correct for files you intend to Edit.
+- DO NOT use WebFetch — use `ctx_fetch_and_index` instead.
+- DO NOT use curl/wget in terminal — use `ctx_fetch_and_index`.
+- Bash is ONLY for git, mkdir, rm, mv, navigation, and short commands.
+- DO NOT use `ctx_execute` or `ctx_execute_file` to create, modify, or overwrite files. ctx_execute is for data analysis, log processing, and computation only.
+
+## File Writing Policy
+
+ALWAYS use the native file editing tools to create and modify files. NEVER use `ctx_execute`, `ctx_execute_file`, or Bash to write file content. This applies to all file types: code, configs, plans, specs, YAML, JSON, markdown.
+
+## Output Constraints
+
+- Keep responses under 500 words.
+- Write artifacts (code, configs) to FILES — never return them as inline text.
+- Return only: file path + 1-line description.
+
+## ctx Commands
+
+| Command | Action |
+|---------|--------|
+| `ctx stats` | Call the ctx_stats MCP tool and display the full output verbatim. |
+| `ctx doctor` | Call the ctx_doctor MCP tool, run the returned shell command, display results as a checklist. |
+| `ctx upgrade` | Call the ctx_upgrade MCP tool, run the returned shell command, display results as a checklist. |
+| `ctx purge` | Call the ctx_purge MCP tool with confirm: true. Warn the user this is irreversible. |
+
+## /clear and /compact Preservation
+
+After /clear or /compact: knowledge base and session stats are preserved. Inform the user: "context-mode knowledge base preserved. Use `ctx purge` if you want to start fresh."

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -43,6 +43,7 @@ export const allowedUnauthenticatedRoutes = [
   'AuthEmailSent',
   'Debug',
   'Maintenance',
+  'PrivacyPage',
   'SignIn',
   'SurveyManager',
   'Login', // @TODO: Remove Login after replacing the login page

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -155,6 +155,10 @@
         Participant Login
       </PvButton>
     </div>
+
+    <footer class="login-footer">
+      <a href="/privacy-page" :class="`login-footer-link login-footer-link--${mode}`">Privacy Policy</a>
+    </footer>
   </div>
 
   <RoarModal
@@ -649,5 +653,31 @@ const sendResetPasswordEmail = () => {
       color: var(--secondary-color) !important;
     }
   }
+}
+
+.login-footer {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.login-footer-link {
+  background-color: white;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  text-decoration: none;
+}
+
+.login-footer-link:hover {
+  text-decoration: underline;
+}
+
+.login-footer-link--participant {
+  color: var(--primary-color);
+}
+
+.login-footer-link--researcher {
+  color: var(--secondary-color);
 }
 </style>

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -23,13 +23,12 @@
         information when particiants login to the website.
       </p>
 
-      <h2>1. Information We Collect</h2>
+      <h2>1. Information We Collect from Participants</h2>
       <ul>
-        <li>Contact information such as name and email when users contact the project or register for access.</li>
         <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
       </ul>
       <p>
-        The policy states that sensitive personal information is not collected unless explicitly required for a
+        Sensitive personal information is not collected unless explicitly required for a
         specific research purpose, with notice and consent where required by law.
       </p>
 
@@ -41,7 +40,7 @@
         <li>Comply with legal obligations.</li>
       </ul>
       <p>
-        The policy states that personal information is not sold or shared with third parties for marketing or
+        Personal information is not sold or shared with third parties for marketing or
         commercial purposes.
       </p>
 
@@ -58,7 +57,7 @@
         <li>Anonymized and geographically abstracted version of your location if you consent to its collection</li>
       </ul>
       <p>
-        The policy states that sensitive personal information is not collected unless explicitly required for a
+        Sensitive personal information is not collected unless explicitly required for a
         specific research purpose, with notice and consent where required by law.
       </p>
 

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -3,33 +3,26 @@
     <section class="surface-card border-round p-4 md:p-5">
       <h1 class="mt-0 mb-2">Privacy Policy for the LEVANTE Project</h1>
       <p class="mt-0 mb-4 text-color-secondary">
-         This dashboard page is initially seeded from the LEVANTE project privacy policy and should be kept aligned
-        with the canonical source.
+        This page includes the LEVANTE researcher privacy policy content directly.
       </p>
-
-      <a
-        href="https://researcher.levante-network.org/privacy-policy"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-block mb-4"
-      >
-        View canonical privacy policy
-      </a>
 
       <h2>Overview</h2>
       <p><strong>Last updated:</strong> June 24, 2025</p>
       <p>
         This Privacy Policy explains how the LEVANTE project collects, uses, stores, and protects personal
-        information when particiants login to the website.
+        information when participants use the website. LEVANTE is committed to protecting privacy and complying with
+        GDPR and CCPA/CPRA.
       </p>
 
-      <h2>1. Information We Collect from Participants</h2>
+      <h2>1. Information We Collect</h2>
       <ul>
+        <li>Contact information such as name and email when users contact the project or register for access.</li>
         <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
+        <li>An anonymized version of assessment results and abstracted location data when participants consent.</li>
       </ul>
       <p>
-        Sensitive personal information is not collected unless explicitly required for a
-        specific research purpose, with notice and consent where required by law.
+        Sensitive personal information is not collected unless explicitly required for a specific research purpose, with
+        notice and consent where required by law.
       </p>
 
       <h2>2. How We Use Your Information</h2>
@@ -40,8 +33,8 @@
         <li>Comply with legal obligations.</li>
       </ul>
       <p>
-        Personal information is not sold or shared with third parties for marketing or
-        commercial purposes.
+        Personal information is not sold or shared with third parties for marketing or commercial purposes. If data is
+        shared with research partners, it is de-identified and handled according to applicable laws.
       </p>
 
       <h2>3. Legal Bases for Processing (GDPR)</h2>
@@ -51,16 +44,6 @@
         <li>Compliance with legal obligations.</li>
       </ul>
 
-      <h2>4. Information you may provide as a participant</h2>
-      <ul>
-        <li>An anonymized version of the results of any of our assessments you undertake.</li>
-        <li>Anonymized and geographically abstracted version of your location if you consent to its collection</li>
-      </ul>
-      <p>
-        Sensitive personal information is not collected unless explicitly required for a
-        specific research purpose, with notice and consent where required by law.
-      </p>
-
       <h2>4. Data Retention</h2>
       <p>
         Personal information is retained only as long as needed for the documented purposes or as required by law,
@@ -68,14 +51,26 @@
       </p>
 
       <h2>5. Your Rights</h2>
-      <p>
-        GDPR rights include access, correction, deletion, restriction, objection, data portability, and consent
-        withdrawal. CCPA/CPRA rights include knowing, deleting, opting out of sale/sharing, and non-discrimination for
-        exercising privacy rights.
-      </p>
+      <p>For EU/EEA residents (GDPR):</p>
+      <ul>
+        <li>Right to access, correct, or delete personal data.</li>
+        <li>Right to restrict or object to processing.</li>
+        <li>Right to data portability.</li>
+        <li>Right to withdraw consent at any time.</li>
+      </ul>
+      <p>For California residents (CCPA/CPRA):</p>
+      <ul>
+        <li>Right to know what personal data is collected, used, and disclosed.</li>
+        <li>Right to request deletion of personal information.</li>
+        <li>Right to opt out of sale or sharing of personal information.</li>
+        <li>Right to non-discrimination for exercising privacy rights.</li>
+      </ul>
 
       <h2>6. Cookies and Tracking</h2>
-      <p>Cookies and similar technologies are used only for essential functionality and analytics.</p>
+      <p>
+        Cookies and similar technologies are used for essential site functionality and analytics. Users can control
+        cookie preferences through browser settings.
+      </p>
 
       <h2>7. Data Security</h2>
       <p>Appropriate technical and organizational safeguards are used to protect personal information.</p>
@@ -91,6 +86,9 @@
         For privacy questions and rights requests, contact
         <a href="mailto:levante-contact@stanford.edu">levante-contact@stanford.edu</a>.
       </p>
+
+      <h2>Special Note: Do Not Sell or Share My Personal Information</h2>
+      <p>The LEVANTE researcher site does not sell or share personal information.</p>
     </section>
   </main>
 </template>

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -20,10 +20,6 @@
         <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
         <li>An anonymized version of assessment results and abstracted location data when participants consent.</li>
       </ul>
-      <p>
-        Sensitive personal information is not collected unless explicitly required for a specific research purpose, with
-        notice and consent where required by law.
-      </p>
 
       <h2>2. How We Use Your Information</h2>
       <ul>
@@ -31,6 +27,7 @@
         <li>Respond to inquiries and support requests.</li>
         <li>Ensure service security and integrity.</li>
         <li>Comply with legal obligations.</li>
+        <li>Stated research purposes.</li>
       </ul>
       <p>
         Personal information is not sold or shared with third parties for marketing or commercial purposes. If data is
@@ -87,7 +84,7 @@
         <a href="mailto:levante-contact@stanford.edu">levante-contact@stanford.edu</a>.
       </p>
 
-      <h2>Special Note: Do Not Sell or Share My Personal Information</h2>
+      <h2>Special Note: We do not sell or Share Personal Information</h2>
       <p>The LEVANTE researcher site does not sell or share personal information.</p>
     </section>
   </main>

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -13,8 +13,8 @@
 
       <h2>1. Information We Collect</h2>
       <ul>
-        <li>For researchersContact information such as name and email when they login to the Dashboard.</li>
-        <li>Technical data such as IP address, browser type, and usage data for site functionality and anonymized data analytics.</li>
+        <li>From researchers: Contact information such as name and email when they login to the Dashboard.</li>
+        <li>From participants: Technical data such as IP address, browser type, and usage data for site functionality and anonymized data analytics.</li>
         <li>An anonymized version of assessment results and abstracted location data when participants consent.</li>
       </ul>
 

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -1,0 +1,97 @@
+<template>
+  <main class="privacy-page container py-5">
+    <section class="surface-card border-round p-4 md:p-5">
+      <h1 class="mt-0 mb-2">Privacy Policy for LEVANTE Researcher Site</h1>
+      <p class="mt-0 mb-4 text-color-secondary">
+        This dashboard page is initially seeded from the LEVANTE researcher privacy policy and should be kept aligned
+        with the canonical source.
+      </p>
+
+      <a
+        href="https://researcher.levante-network.org/privacy-policy"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-block mb-4"
+      >
+        View canonical privacy policy
+      </a>
+
+      <h2>Overview</h2>
+      <p><strong>Last updated:</strong> June 24, 2025</p>
+      <p>
+        This Privacy Policy explains how the LEVANTE project collects, uses, stores, and protects personal
+        information when particiants login to the website.
+      </p>
+
+      <h2>1. Information We Collect from Researchers</h2>
+      <ul>
+        <li>Contact information such as name and email when users contact the project or register for access.</li>
+        <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
+      </ul>
+      <p>
+        The policy states that sensitive personal information is not collected unless explicitly required for a
+        specific research purpose, with notice and consent where required by law.
+      </p>
+
+      <h2>2. How We Use Your Information</h2>
+      <ul>
+        <li>Operate and maintain website features.</li>
+        <li>Respond to inquiries and support requests.</li>
+        <li>Ensure service security and integrity.</li>
+        <li>Comply with legal obligations.</li>
+      </ul>
+      <p>
+        The policy states that personal information is not sold or shared with third parties for marketing or
+        commercial purposes.
+      </p>
+
+      <h2>3. Legal Bases for Processing (GDPR)</h2>
+      <ul>
+        <li>User consent where required.</li>
+        <li>Legitimate interests in operating the website and supporting research.</li>
+        <li>Compliance with legal obligations.</li>
+      </ul>
+
+      <h2>4. Information you may provide as a participant</h2>
+      <ul>
+        <li>An anonymized version of the results of any of our assessments you undertake.</li>
+        <li>Anonymized and geographically abstracted version of your location if you consent to its collection</li>
+      </ul>
+      <p>
+        The policy states that sensitive personal information is not collected unless explicitly required for a
+        specific research purpose, with notice and consent where required by law.
+      </p>
+
+      <h2>4. Data Retention</h2>
+      <p>
+        Personal information is retained only as long as needed for the documented purposes or as required by law,
+        then deleted or anonymized.
+      </p>
+
+      <h2>5. Your Rights</h2>
+      <p>
+        GDPR rights include access, correction, deletion, restriction, objection, data portability, and consent
+        withdrawal. CCPA/CPRA rights include knowing, deleting, opting out of sale/sharing, and non-discrimination for
+        exercising privacy rights.
+      </p>
+
+      <h2>6. Cookies and Tracking</h2>
+      <p>Cookies and similar technologies are used only for essential functionality and analytics.</p>
+
+      <h2>7. Data Security</h2>
+      <p>Appropriate technical and organizational safeguards are used to protect personal information.</p>
+
+      <h2>8. International Transfers</h2>
+      <p>If cross-border transfers occur, adequate safeguards are applied according to relevant privacy laws.</p>
+
+      <h2>9. Changes to This Policy</h2>
+      <p>Policy updates are posted on this page with an updated effective date.</p>
+
+      <h2>10. Contact</h2>
+      <p>
+        For privacy questions and rights requests, contact
+        <a href="mailto:levante-contact@stanford.edu">levante-contact@stanford.edu</a>.
+      </p>
+    </section>
+  </main>
+</template>

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -2,22 +2,19 @@
   <main class="privacy-page container py-5">
     <section class="surface-card border-round p-4 md:p-5">
       <h1 class="mt-0 mb-2">Privacy Policy for the LEVANTE Project</h1>
-      <p class="mt-0 mb-4 text-color-secondary">
-        This page includes the LEVANTE researcher privacy policy content directly.
-      </p>
 
       <h2>Overview</h2>
       <p><strong>Last updated:</strong> June 24, 2025</p>
       <p>
         This Privacy Policy explains how the LEVANTE project collects, uses, stores, and protects personal
-        information when participants use the website. LEVANTE is committed to protecting privacy and complying with
-        GDPR and CCPA/CPRA.
+        information when participants use the website and associated web applications. LEVANTE is committed to protecting privacy and complying with
+        international laws including GDPR and CCPA/CPRA.
       </p>
 
       <h2>1. Information We Collect</h2>
       <ul>
-        <li>Contact information such as name and email when users contact the project or register for access.</li>
-        <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
+        <li>For researchersContact information such as name and email when they login to the Dashboard.</li>
+        <li>Technical data such as IP address, browser type, and usage data for site functionality and anonymized data analytics.</li>
         <li>An anonymized version of assessment results and abstracted location data when participants consent.</li>
       </ul>
 
@@ -85,7 +82,7 @@
       </p>
 
       <h2>Special Note: We do not sell or Share Personal Information</h2>
-      <p>The LEVANTE researcher site does not sell or share personal information.</p>
+      <p>The LEVANTE project site does not sell or share personal information.</p>
     </section>
   </main>
 </template>

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -1,9 +1,9 @@
 <template>
   <main class="privacy-page container py-5">
     <section class="surface-card border-round p-4 md:p-5">
-      <h1 class="mt-0 mb-2">Privacy Policy for LEVANTE Researcher Site</h1>
+      <h1 class="mt-0 mb-2">Privacy Policy for the LEVANTE Project</h1>
       <p class="mt-0 mb-4 text-color-secondary">
-        This dashboard page is initially seeded from the LEVANTE researcher privacy policy and should be kept aligned
+         This dashboard page is initially seeded from the LEVANTE project privacy policy and should be kept aligned
         with the canonical source.
       </p>
 
@@ -23,7 +23,7 @@
         information when particiants login to the website.
       </p>
 
-      <h2>1. Information We Collect from Researchers</h2>
+      <h2>1. Information We Collect</h2>
       <ul>
         <li>Contact information such as name and email when users contact the project or register for access.</li>
         <li>Technical data such as IP address, browser type, and usage data for site functionality and analytics.</li>
@@ -95,3 +95,7 @@
     </section>
   </main>
 </template>
+
+<script setup lang="ts">
+defineOptions({ name: 'PrivacyPage' });
+</script>

--- a/src/pages/SignIn.vue
+++ b/src/pages/SignIn.vue
@@ -56,9 +56,8 @@
           </div>
         </section> -->
       </section>
-      <footer style="display: none">
-        <!-- TODO: figure out a link for this -->
-        <a href="#trouble">{{ $t('pageSignIn.havingTrouble') }}</a>
+      <footer class="signin-footer">
+        <a href="/privacy-page" class="signin-footer-link">Privacy Policy</a>
       </footer>
     </section>
   </div>
@@ -306,5 +305,21 @@ input.p-inputtext.p-component.p-password-input {
 }
 div#password {
   width: 100% !important;
+}
+
+.signin-footer {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.signin-footer-link {
+  color: var(--primary-color);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.signin-footer-link:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -252,6 +252,15 @@ const routes: Array<RouteRecordRaw> = [
     },
   },
   {
+    path: '/privacy-page',
+    name: 'PrivacyPage',
+    component: () => import('@/pages/PrivacyPage.vue'),
+    meta: {
+      pageTitle: 'Privacy Policy',
+      allowedRoles: ['*'],
+    },
+  },
+  {
     path: '/:pathMatch(.*)*',
     name: 'NotFound',
     component: () => import('@/pages/NotFound.vue'),


### PR DESCRIPTION
## Summary
- add a new public `PrivacyPage` route and page seeded from the researcher privacy policy
- add a `Privacy Policy` footer link on both sign-in entry pages (`/signin` and `/login`)
- style footer links for visibility and mode-aware theming on `Login.vue`

NOT PERFECT, but right now we have nothing and this might be enough for now, or at least a good start. Feel free to hack on it.

## Test plan
- [x] Run `npx eslint src/pages/PrivacyPage.vue src/pages/SignIn.vue src/pages/Login.vue src/router/index.ts`
- [ ] Open `/signin` and verify footer link navigates to `/privacy-page`
- [ ] Open `/login` in participant and researcher modes and verify footer link styling and navigation
- [ ] Verify privacy page content and canonical link render correctly