### PR TITLE
Change documentation link on welcome page to general docs

### DIFF
--- a/src/pages/HomeAdministrator.vue
+++ b/src/pages/HomeAdministrator.vue
@@ -20,7 +20,7 @@
         </div>
 
         <div class="docs-button-wrapper">
-          <DocsButton href="https://researcher.levante-network.org/dashboard/add-users" label="Documentation" />
+          <DocsButton href="https://researcher.levante-network.org/dashboard" label="Documentation" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Proposed changes

Changed doc link in the Welcome Page from `https://researcher.levante-network.org/dashboard/add-users` to `https://researcher.levante-network.org/dashboard`.


https://github.com/user-attachments/assets/00c17ae6-14e8-43e0-a70d-ee8b61eba3c0



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
