### PR TITLE
Fix Sentry environment tagging for dev deployments

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -31,6 +31,7 @@ export function initSentry(app: App) {
   Sentry.init({
     app,
     dsn,
+    environment: import.meta.env.VITE_FIREBASE_PROJECT === 'DEV' ? 'development' : 'production',
     integrations: [
       Sentry.replayIntegration({
         maskAllText: true,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -31,7 +31,8 @@ export function initSentry(app: App) {
   Sentry.init({
     app,
     dsn,
-    environment: import.meta.env.VITE_FIREBASE_PROJECT?.toUpperCase() === 'DEV' ? 'development' : 'production',
+    environment:
+      (import.meta.env.VITE_FIREBASE_PROJECT ?? 'PROD').toUpperCase() === 'DEV' ? 'development' : 'production',
     integrations: [
       Sentry.replayIntegration({
         maskAllText: true,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -31,7 +31,7 @@ export function initSentry(app: App) {
   Sentry.init({
     app,
     dsn,
-    environment: import.meta.env.VITE_FIREBASE_PROJECT === 'DEV' ? 'development' : 'production',
+    environment: import.meta.env.VITE_FIREBASE_PROJECT?.toUpperCase() === 'DEV' ? 'development' : 'production',
     integrations: [
       Sentry.replayIntegration({
         maskAllText: true,


### PR DESCRIPTION
## Summary
- set Sentry `environment` to `development` when `VITE_FIREBASE_PROJECT` is `DEV`
- keep `production` tagging for non-DEV builds so alerting stays scoped correctly
- ensure preview/dev Firebase hosting errors are separable from production in one Sentry project

## Test plan
- [x] Run `npm run build:dev` and confirm `import.meta.env.VITE_FIREBASE_PROJECT === 'DEV'`
- [x] Verify `src/sentry.ts` sets `environment` to `development` for DEV builds
- [ ] Trigger a dev error and confirm Sentry event environment is `development`
- [ ] Trigger/probe a prod error and confirm Sentry event environment is `production`