### PR TITLE
fix: derive participant site locally instead of fetching district docs (fixes DASHBOARD-13S 403s)

### DIFF
--- a/src/pages/HomeParticipant.vue
+++ b/src/pages/HomeParticipant.vue
@@ -100,7 +100,6 @@ import useTasksQuery from '@/composables/queries/useTasksQuery';
 import useSurveyResponsesQuery from '@/composables/useSurveyResponses/useSurveyResponses';
 import useUpdateConsentMutation from '@/composables/mutations/useUpdateConsentMutation';
 import useSignOutMutation from '@/composables/mutations/useSignOutMutation';
-import useDistrictsQuery from '@/composables/queries/useDistrictsQuery';
 import ConsentModal from '@/components/ConsentModal.vue';
 import GameTabs from '@/components/GameTabs.vue';
 import ParticipantSidebar from '@/components/ParticipantSidebar.vue';
@@ -162,14 +161,6 @@ unsubscribe = authStore.$subscribe(async (mutation, state) => {
 
 onMounted(async () => {
   if (roarfirekit.value.restConfig) init();
-});
-
-const {
-  data: districtsData,
-  isLoading: isLoadingDistricts,
-  isFetching: isFetchingDistricts,
-} = useDistrictsQuery(currentUserData.value?.districts?.current, {
-  enabled: initialized,
 });
 
 const {
@@ -253,11 +244,11 @@ const { data: surveyResponsesData } = useSurveyResponsesQuery({
 });
 
 const isLoading = computed(() => {
-  return isLoadingUserData.value || isLoadingAssignments.value || isLoadingTasks.value || isLoadingDistricts.value;
+  return isLoadingUserData.value || isLoadingAssignments.value || isLoadingTasks.value;
 });
 
 const isFetching = computed(() => {
-  return isFetchingUserData.value || isFetchingAssignments.value || isFetchingTasks.value || isFetchingDistricts.value;
+  return isFetchingUserData.value || isFetchingAssignments.value || isFetchingTasks.value;
 });
 
 const hasAssignments = computed(() => {
@@ -309,19 +300,17 @@ const userType = computed(() => {
   return toRaw(userData.value)?.userType?.toLowerCase();
 });
 
-// Watch for when districts data changes
+// Derive site for telemetry from the user's own roles; participants cannot read district docs (403).
 watch(
-  districtsData,
-  (newDistrictsData) => {
-    if (newDistrictsData) {
-      const rawDistrictsData = toRaw(newDistrictsData)?.[0];
-      if (rawDistrictsData?.name) {
-        logger.setAdditionalProperties({
-          siteId: rawDistrictsData?.id,
-          siteName: rawDistrictsData?.name,
-        });
-      }
-    }
+  currentUserData,
+  (user) => {
+    const currentDistrictId = user?.districts?.current?.[0];
+    if (!currentDistrictId) return;
+    const roles = user?.roles ?? [];
+    const matchingRole = roles.find((role) => role?.siteId === currentDistrictId) ?? roles[0];
+    const siteId = matchingRole?.siteId ?? currentDistrictId;
+    const siteName = matchingRole?.siteName;
+    logger.setAdditionalProperties({ siteId, ...(siteName ? { siteName } : {}) });
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Summary

The participant (child) home page fetched the signed-in child's **district document(s)** via `useDistrictsQuery` → Firestore `documents:batchGet`. Participants are **not permitted to read `districts/*`** under the security rules, so this returned **403 Forbidden on every child login**.

This is the top Axios error in production: **[DASHBOARD-13S](https://levante-framework.sentry.io/issues/DASHBOARD-13S)** — **3,660 events / 928 users in the last 30 days** (2,164 users all-time), ongoing since **2026-04-30**.

The fetched district was used for exactly one thing: tagging telemetry with `siteId`/`siteName`. Those values already live on the participant's **own** user document (`roles[].siteId` / `roles[].siteName`), so we can derive them locally and drop the forbidden request entirely.

## Where it came from

```167:173:src/pages/HomeParticipant.vue
const {
  data: districtsData,
  isLoading: isLoadingDistricts,
  isFetching: isFetchingDistricts,
} = useDistrictsQuery(currentUserData.value?.districts?.current, { enabled: initialized });
```

`useDistrictsQuery` → `fetchDocumentsById(DISTRICTS, ids)` → `POST …/documents:batchGet` on `districts/<id>` → 403 for participants. Its only consumer was a watcher that copied `name`/`id` into `logger.setAdditionalProperties({ siteId, siteName })`.

## The change

- Remove `useDistrictsQuery` from the participant home.
- Derive `siteId`/`siteName` locally in the watcher from `currentUserData` (the user's own doc), matching the role whose `siteId` equals the current district (falling back to the first role).
- Drop `isLoadingDistricts` / `isFetchingDistricts` from the page loading gates.

This is not just noise removal — it's a **behavioral improvement**. Today the fetch always fails for participants, so **no site tag is set at all**; after this change the tag is populated locally.

## Data backing the approach (admin-prod, sample of 8,935 students)

- **90.3%** of students have `districts.current` set (the case that triggered the fetch).
- Of those, **99.1%** have a `roles` entry with matching `siteId` **and** `siteName` → fully derivable locally.
- **`siteId` is derivable ~100%** (roles' `siteId` matches the current district); only the human-readable name is occasionally absent.
- The **0.9%** without a derivable name are all one site — **`CO-rural-pilot`** (`mnmxUgnG1JGYmCRFY7sM`) — whose `roles` were written without `siteName`. Those children still get `siteId` (same-or-better than today, which is nothing). Recommend a separate data backfill so `roles` always include `siteName`.

## Impact

- Eliminates ~3,660 failed Firestore reads + Sentry errors per month from real children at sign-in (top affected sites: CA-western-pilot, rfp1-utdt-ar-main, rfp1-utdt-intl-ys).
- Improves site telemetry coverage for participants from 0% → ~99%.
- No security-rules change needed; the rules correctly deny participants district reads — the bug was the client asking.

## Test plan

- [ ] Sign in as a participant with a `districts.current` and confirm no 403 to `documents:batchGet` for `districts/*` in the network tab.
- [ ] Confirm Sentry/PostHog events for that session carry `siteId` (and `siteName` where present in roles).
- [ ] Sign in as a `CO-rural-pilot` participant and confirm graceful behavior (siteId set, no crash, no siteName).
- [ ] Confirm the participant page still loads/renders normally (loading gates unaffected).
- [ ] Confirm DASHBOARD-13S stops accruing new events after deploy.