### PR TITLE
fix: drop unauthenticated Firestore permission-denied noise in Sentry (DASHBOARD-4)

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -76,6 +76,15 @@ export function initSentry(app: App) {
         delete event.contexts.geo;
       }
 
+      // Drop benign Firestore permission-denied errors raised while unauthenticated
+      // (auth-transition / signout race). Genuine denials for signed-in users are kept.
+      const isPermissionDenied = (event.exception?.values ?? []).some(
+        (value) => typeof value.value === 'string' && /Missing or insufficient permissions/i.test(value.value),
+      );
+      if (isPermissionDenied && !authStore.isAuthenticated()) {
+        return null;
+      }
+
       return event;
     },
   });


### PR DESCRIPTION
## Summary

[`DASHBOARD-4` — `FirebaseError: Missing or insufficient permissions`](https://levante-framework.sentry.io/issues/DASHBOARD-4) (28 users, ~2,520 events, ongoing since 2024-12) is dominated by **unhandled Firestore `permission-denied` rejections that fire while the user is unauthenticated** — the pre-login / signout auth-transition race, largely from firekit's internal Firestore reads/listeners.

These are **benign**: an unauthenticated read is correctly denied by the security rules and the app redirects to `/signin`. They surface only because Sentry's global handler captures the unhandled rejection.

## Evidence

- Recent 30d: **37 of ~40 prod events have `user.email: null`** (no authenticated user), `mechanism: instrument` (unhandled rejection), no stacktrace.
- Almost all events are on `url: /signin` (or the initial load redirecting there); the few with an authenticated user are a different, genuine signal we want to keep.
- The dashboard's own Firestore SDK reads (`UsersRepository`, `AdministrationsRepository`, `useSuperAdminsQuery`, …) are role-gated and `try/catch`-wrapped, so they'd be `handled` — the uncaught ones originate below the app (firekit auth-transition reads).

## Change

Extend the existing `beforeSend` in `src/sentry.ts` to drop `Missing or insufficient permissions` events **only when there is no authenticated user** (`!authStore.isAuthenticated()`). Genuine permission denials for signed-in admins are still reported.

```ts
const isPermissionDenied = (event.exception?.values ?? []).some(
  (value) => typeof value.value === 'string' && /Missing or insufficient permissions/i.test(value.value),
);
if (isPermissionDenied && !authStore.isAuthenticated()) {
  return null;
}
```

## Why filter rather than "fix" the read

The reads happen inside firekit during the unauthenticated window and the user-facing behavior is already correct (redirect to sign-in). There's nothing to fix in app code without changing firekit's listener teardown; the actionable app-side improvement is to stop reporting the benign noise while preserving real (authenticated) permission errors.

Follow-up (separate): file a firekit issue to ensure its Firestore listeners are torn down before/҂on sign-out so the rejection isn't produced at all.

## Test plan

- [ ] Load `/signin` unauthenticated (and sign out) and confirm no new DASHBOARD-4 events are ingested.
- [ ] Confirm an authenticated admin hitting a genuine `permission-denied` (e.g. a real rules gap) is still reported.
- [ ] Confirm no other error types are affected by the filter.